### PR TITLE
feat(sprint2): architecture, perf, localization, Coil 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ coverage/
 
 # Temporary instruction files (should not be committed)
 COMMIT_INSTRUCTIONS.md
+.gitnexus

--- a/app/src/main/java/com/vamsi/worldcountriesinformation/WorldCountriesApplication.kt
+++ b/app/src/main/java/com/vamsi/worldcountriesinformation/WorldCountriesApplication.kt
@@ -2,14 +2,18 @@ package com.vamsi.worldcountriesinformation
 
 import android.app.Application
 import android.os.StrictMode
+import com.vamsi.worldcountriesinformation.startup.CachePreloader
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
+import javax.inject.Inject
 
 /**
  * Application class for World Countries Information app.
  */
 @HiltAndroidApp
 class WorldCountriesApplication : Application() {
+
+    @Inject lateinit var cachePreloader: CachePreloader
 
     override fun onCreate() {
         // Enable strict mode before Dagger creates graph
@@ -21,6 +25,8 @@ class WorldCountriesApplication : Application() {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+
+        cachePreloader.warm()
     }
 
     private fun enableStrictMode() {

--- a/app/src/main/java/com/vamsi/worldcountriesinformation/startup/CachePreloader.kt
+++ b/app/src/main/java/com/vamsi/worldcountriesinformation/startup/CachePreloader.kt
@@ -1,0 +1,35 @@
+package com.vamsi.worldcountriesinformation.startup
+
+import com.vamsi.worldcountriesinformation.core.database.dao.CountryDao
+import com.vamsi.worldcountriesinformation.domain.di.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Pre-warms the Room countries cache on cold start so the first list render
+ * does not pay the SQLite open + initial query cost on the UI thread's
+ * dispatch path.
+ *
+ * Fire-and-forget: failures here must never crash startup.
+ */
+@Singleton
+class CachePreloader @Inject constructor(
+    private val countryDao: CountryDao,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+
+    fun warm() {
+        scope.launch {
+            runCatching { countryDao.getAllCountriesOnce() }
+                .onSuccess { Timber.d("Pre-warmed Room cache: ${it.size} countries") }
+                .onFailure { Timber.w(it, "Cache pre-warm failed") }
+        }
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="country_flag_ada">Landesflagge</string>
+    <string name="country_name_label">"Name: "</string>
+    <string name="capital_city_label">"Hauptstadt: "</string>
+    <string name="population_label">"Bevölkerung: "</string>
+    <string name="calling_code_label">"Vorwahl: "</string>
+    <string name="language_label">"Sprachen: "</string>
+    <string name="currency_label">"Währungen: "</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="country_flag_ada">bandera del país</string>
+    <string name="country_name_label">"Nombre: "</string>
+    <string name="capital_city_label">"Capital: "</string>
+    <string name="population_label">"Población: "</string>
+    <string name="calling_code_label">"Código de llamada: "</string>
+    <string name="language_label">"Idiomas: "</string>
+    <string name="currency_label">"Monedas: "</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="country_flag_ada">drapeau du pays</string>
+    <string name="country_name_label">"Nom : "</string>
+    <string name="capital_city_label">"Capitale : "</string>
+    <string name="population_label">"Population : "</string>
+    <string name="calling_code_label">"Indicatif téléphonique : "</string>
+    <string name="language_label">"Langues : "</string>
+    <string name="currency_label">"Devises : "</string>
+</resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="country_flag_ada">देश का ध्वज</string>
+    <string name="country_name_label">"नाम: "</string>
+    <string name="capital_city_label">"राजधानी: "</string>
+    <string name="population_label">"जनसंख्या: "</string>
+    <string name="calling_code_label">"कॉलिंग कोड: "</string>
+    <string name="language_label">"भाषाएँ: "</string>
+    <string name="currency_label">"मुद्राएँ: "</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">World Countries Information</string>
+    <string name="app_name" translatable="false">World Countries Information</string>
     <string name="country_flag_ada">country flag</string>
 
     <string name="country_name_label">"Name: "</string>

--- a/benchmark/src/main/java/com/vamsi/worldcountriesinformation/benchmark/DetailsOpenBenchmark.kt
+++ b/benchmark/src/main/java/com/vamsi/worldcountriesinformation/benchmark/DetailsOpenBenchmark.kt
@@ -1,0 +1,46 @@
+package com.vamsi.worldcountriesinformation.benchmark
+
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Macrobenchmark that taps the first country in the list to navigate into
+ * the details screen, measuring frame timings during the transition.
+ */
+@RunWith(AndroidJUnit4::class)
+class DetailsOpenBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun openCountryDetails() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE,
+        metrics = listOf(FrameTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.WARM,
+        setupBlock = {
+            pressHome()
+            startActivityAndWait()
+        },
+    ) {
+        device.wait(Until.hasObject(By.scrollable(true)), 5_000)
+        val list = device.findObject(By.scrollable(true)) ?: return@measureRepeated
+        val firstChild = list.children.firstOrNull() ?: return@measureRepeated
+        firstChild.click()
+        device.waitForIdle()
+        device.pressBack()
+        device.waitForIdle()
+    }
+
+    private companion object {
+        const val TARGET_PACKAGE = "com.vamsi.worldcountriesinformation"
+    }
+}

--- a/benchmark/src/main/java/com/vamsi/worldcountriesinformation/benchmark/ScrollBenchmark.kt
+++ b/benchmark/src/main/java/com/vamsi/worldcountriesinformation/benchmark/ScrollBenchmark.kt
@@ -1,0 +1,49 @@
+package com.vamsi.worldcountriesinformation.benchmark
+
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Macrobenchmark that scrolls the country list and measures frame timing.
+ *
+ * Run on a physical device:
+ * `./gradlew :benchmark:connectedBenchmarkAndroidTest`
+ */
+@RunWith(AndroidJUnit4::class)
+class ScrollBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun scrollCountriesList() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE,
+        metrics = listOf(FrameTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.WARM,
+        setupBlock = {
+            pressHome()
+            startActivityAndWait()
+        },
+    ) {
+        device.wait(Until.hasObject(By.scrollable(true)), 5_000)
+        val list = device.findObject(By.scrollable(true)) ?: return@measureRepeated
+        list.setGestureMargin(device.displayWidth / 5)
+        repeat(3) {
+            list.fling(Direction.DOWN)
+            device.waitForIdle()
+        }
+    }
+
+    private companion object {
+        const val TARGET_PACKAGE = "com.vamsi.worldcountriesinformation"
+    }
+}

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
 dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.kotlin.composeCompilerGradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
 }
 

--- a/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
@@ -2,6 +2,7 @@ import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 
 class AndroidComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -13,6 +14,15 @@ class AndroidComposeConventionPlugin : Plugin<Project> {
             extensions.configure<LibraryExtension> {
                 buildFeatures {
                     compose = true
+                }
+            }
+
+            extensions.configure<ComposeCompilerGradlePluginExtension> {
+                val stabilityConfig = rootProject.file("compose_compiler_config.conf")
+                if (stabilityConfig.exists()) {
+                    stabilityConfigurationFiles.add(
+                        project.layout.projectDirectory.file(stabilityConfig.absolutePath)
+                    )
                 }
             }
         }

--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -1,0 +1,27 @@
+# Compose Compiler stability configuration.
+#
+# Marks domain types as stable so Compose can skip recomposition when their
+# inputs are referentially equal. The domain layer is pure Kotlin (no Compose
+# dependency), so we declare stability here rather than annotating the classes.
+#
+# Format: fully-qualified class name (one per line, supports wildcards).
+# See: https://developer.android.com/develop/ui/compose/performance/stability/fix#configuration-file
+
+# Country domain models — all immutable data classes
+com.vamsi.worldcountriesinformation.domainmodel.Country
+com.vamsi.worldcountriesinformation.domainmodel.Currency
+com.vamsi.worldcountriesinformation.domainmodel.Language
+com.vamsi.worldcountriesinformation.domainmodel.SearchHistoryEntry
+com.vamsi.worldcountriesinformation.domainmodel.SortOrder
+com.vamsi.worldcountriesinformation.domainmodel.Regions
+
+# Domain core wrappers
+com.vamsi.worldcountriesinformation.domain.core.ApiResponse
+com.vamsi.worldcountriesinformation.domain.core.ApiResponse.*
+com.vamsi.worldcountriesinformation.domain.core.CachePolicy
+
+# Standard Java collections we treat as immutable when stored in immutable
+# state holders (we never mutate the underlying list — we copy on update).
+java.util.List
+java.util.Set
+java.util.Map

--- a/core/common/src/main/kotlin/com/vamsi/worldcountriesinformation/core/common/error/AppError.kt
+++ b/core/common/src/main/kotlin/com/vamsi/worldcountriesinformation/core/common/error/AppError.kt
@@ -1,0 +1,85 @@
+package com.vamsi.worldcountriesinformation.core.common.error
+
+import android.content.Context
+import android.content.res.Resources
+import androidx.annotation.StringRes
+import com.vamsi.worldcountriesinformation.core.common.R
+import kotlinx.coroutines.CancellationException
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+/**
+ * Canonical, UI-agnostic error model used across the app.
+ *
+ * ViewModels should expose `AppError` (not raw `Throwable` or hardcoded
+ * English strings). The UI layer translates an `AppError` into a localized
+ * string via [Context.message] (or via `stringResource(error.messageRes, ...)`)
+ * so error copy participates in the regular resource/localization pipeline.
+ */
+sealed interface AppError {
+    @get:StringRes
+    val messageRes: Int
+
+    val formatArgs: Array<Any> get() = emptyArray()
+
+    data object Network : AppError {
+        override val messageRes: Int = R.string.error_network
+    }
+
+    data object Timeout : AppError {
+        override val messageRes: Int = R.string.error_timeout
+    }
+
+    data object NoCachedData : AppError {
+        override val messageRes: Int = R.string.error_no_cached_data
+    }
+
+    data class NotFound(val identifier: String) : AppError {
+        override val messageRes: Int = R.string.error_not_found
+        override val formatArgs: Array<Any> get() = arrayOf(identifier)
+    }
+
+    /**
+     * Caller-specified fallback when the cause is unknown. Lets each screen
+     * pick a more specific message (e.g. "Failed to load countries" vs
+     * "Failed to load country details") without inflating the AppError tree.
+     */
+    data class Generic(@get:StringRes override val messageRes: Int) : AppError
+
+    data object Unknown : AppError {
+        override val messageRes: Int = R.string.error_unknown
+    }
+}
+
+/**
+ * Map a [Throwable] to an [AppError]. Cooperative cancellation is preserved.
+ *
+ * String-matching on `message` mirrors what the existing ViewModels already do;
+ * once domain layer surfaces typed exceptions we should match on those instead.
+ */
+fun Throwable.toAppError(fallback: AppError = AppError.Unknown): AppError {
+    if (this is CancellationException) throw this
+    val msg = message.orEmpty()
+    return when {
+        msg.contains("No cached data", ignoreCase = true) -> AppError.NoCachedData
+        msg.contains("not found", ignoreCase = true) -> AppError.NotFound(identifier = "")
+        this is SocketTimeoutException -> AppError.Timeout
+        msg.contains("timeout", ignoreCase = true) -> AppError.Timeout
+        this is UnknownHostException -> AppError.Network
+        this is IOException -> AppError.Network
+        msg.contains("network", ignoreCase = true) -> AppError.Network
+        else -> fallback
+    }
+}
+
+/** Localize the given [AppError] using the application's resources. */
+fun Context.message(error: AppError): String =
+    getString(error.messageRes, *error.formatArgs)
+
+/**
+ * Localize the given [AppError] from a [Resources] handle. Prefer this in Compose
+ * via `LocalResources.current` so configuration changes invalidate properly.
+ */
+fun Resources.message(error: AppError): String =
+    getString(error.messageRes, *error.formatArgs)

--- a/core/common/src/main/kotlin/com/vamsi/worldcountriesinformation/core/common/mvi/MVIViewModel.kt
+++ b/core/common/src/main/kotlin/com/vamsi/worldcountriesinformation/core/common/mvi/MVIViewModel.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.launch
  *                     setState { copy(isLoading = false, countries = countries) }
  *                 }
  *                 .onFailure { error ->
- *                     setState { copy(isLoading = false, errorMessage = error.message) }
+ *                     setState { copy(isLoading = false, error = error.toAppError()) }
  *                 }
  *         }
  *     }

--- a/core/common/src/main/res/values-de/strings.xml
+++ b/core/common/src/main/res/values-de/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_network">Netzwerkfehler. Überprüfe deine Verbindung und versuche es erneut.</string>
+    <string name="error_timeout">Zeitüberschreitung der Verbindung. Überprüfe deine Internetverbindung und versuche es erneut.</string>
+    <string name="error_no_cached_data">Keine zwischengespeicherten Daten verfügbar. Bitte stelle eine Internetverbindung her.</string>
+    <string name="error_not_found">Land mit dem Code \'%1$s\' wurde nicht gefunden.</string>
+    <string name="error_load_countries_failed">Länder konnten nicht geladen werden. Versuche es erneut.</string>
+    <string name="error_load_country_details_failed">Länderdetails konnten nicht geladen werden. Versuche es erneut.</string>
+    <string name="error_unknown">Etwas ist schiefgelaufen. Versuche es erneut.</string>
+</resources>

--- a/core/common/src/main/res/values-es/strings.xml
+++ b/core/common/src/main/res/values-es/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_network">Error de red. Comprueba tu conexión e inténtalo de nuevo.</string>
+    <string name="error_timeout">Tiempo de conexión agotado. Comprueba tu conexión a Internet e inténtalo de nuevo.</string>
+    <string name="error_no_cached_data">No hay datos en caché. Conéctate a Internet.</string>
+    <string name="error_not_found">No se encontró el país con el código \'%1$s\'.</string>
+    <string name="error_load_countries_failed">No se pudieron cargar los países. Inténtalo de nuevo.</string>
+    <string name="error_load_country_details_failed">No se pudieron cargar los detalles del país. Inténtalo de nuevo.</string>
+    <string name="error_unknown">Algo salió mal. Inténtalo de nuevo.</string>
+</resources>

--- a/core/common/src/main/res/values-fr/strings.xml
+++ b/core/common/src/main/res/values-fr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_network">Erreur réseau. Vérifiez votre connexion et réessayez.</string>
+    <string name="error_timeout">Délai de connexion dépassé. Vérifiez votre connexion Internet et réessayez.</string>
+    <string name="error_no_cached_data">Aucune donnée en cache. Connectez-vous à Internet.</string>
+    <string name="error_not_found">Pays avec le code \'%1$s\' introuvable.</string>
+    <string name="error_load_countries_failed">Échec du chargement des pays. Réessayez.</string>
+    <string name="error_load_country_details_failed">Échec du chargement des détails du pays. Réessayez.</string>
+    <string name="error_unknown">Une erreur s\'est produite. Réessayez.</string>
+</resources>

--- a/core/common/src/main/res/values-hi/strings.xml
+++ b/core/common/src/main/res/values-hi/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_network">नेटवर्क त्रुटि। कृपया अपना कनेक्शन जाँचें और पुनः प्रयास करें।</string>
+    <string name="error_timeout">कनेक्शन का समय समाप्त। कृपया अपना इंटरनेट जाँचें और पुनः प्रयास करें।</string>
+    <string name="error_no_cached_data">कोई कैश्ड डेटा उपलब्ध नहीं है। कृपया इंटरनेट से कनेक्ट करें।</string>
+    <string name="error_not_found">कोड \'%1$s\' वाला देश नहीं मिला।</string>
+    <string name="error_load_countries_failed">देश लोड करने में विफल। कृपया पुनः प्रयास करें।</string>
+    <string name="error_load_country_details_failed">देश का विवरण लोड करने में विफल। कृपया पुनः प्रयास करें।</string>
+    <string name="error_unknown">कुछ गलत हो गया। कृपया पुनः प्रयास करें।</string>
+</resources>

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- AppError messages. Used by core.common.error.AppError -->
+    <string name="error_network">Network error. Please check your connection and try again.</string>
+    <string name="error_timeout">Connection timeout. Please check your internet and try again.</string>
+    <string name="error_no_cached_data">No cached data available. Please connect to the internet.</string>
+    <string name="error_not_found">Country with code \'%1$s\' not found.</string>
+    <string name="error_load_countries_failed">Failed to load countries. Please try again.</string>
+    <string name="error_load_country_details_failed">Failed to load country details. Please try again.</string>
+    <string name="error_unknown">Something went wrong. Please try again.</string>
+</resources>

--- a/core/network/src/main/kotlin/com/vamsi/worldcountriesinformation/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/vamsi/worldcountriesinformation/core/network/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.vamsi.worldcountriesinformation.core.network.di
 
+import android.content.Context
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.vamsi.worldcountriesinformation.core.common.Constants
 import com.vamsi.worldcountriesinformation.core.network.BuildConfig
@@ -9,14 +10,18 @@ import com.vamsi.worldcountriesinformation.core.network.interceptor.HttpsOnlyInt
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import okhttp3.Cache
+import okhttp3.CacheControl
 import okhttp3.ConnectionSpec
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.TlsVersion
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import java.io.File
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -136,10 +141,59 @@ object NetworkModule {
      * @see HttpsOnlyInterceptor for HTTPS enforcement details
      * @see provideRetrofit for Retrofit configuration
      */
+    private const val HTTP_CACHE_DIR = "rest-countries-http-cache"
+    private const val HTTP_CACHE_SIZE_BYTES = 10L * 1024L * 1024L // 10 MB
+    private const val HTTP_CACHE_MAX_AGE_SECONDS = 60 * 60 // 1 hour
+    private const val HTTP_CACHE_MAX_STALE_SECONDS = 60 * 60 * 24 * 7 // 7 days
+
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient {
+    fun provideHttpCache(@ApplicationContext context: Context): Cache {
+        val cacheDir = File(context.cacheDir, HTTP_CACHE_DIR)
+        return Cache(cacheDir, HTTP_CACHE_SIZE_BYTES)
+    }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(httpCache: Cache): OkHttpClient {
         return OkHttpClient.Builder().apply {
+            cache(httpCache)
+
+            // Force a sane Cache-Control on responses from REST Countries.
+            // The upstream API does not always set caching headers, so we rewrite
+            // the response to allow OkHttp to serve from disk for an hour and
+            // fall back to stale data for up to a week when offline.
+            addNetworkInterceptor { chain ->
+                val response = chain.proceed(chain.request())
+                if (response.isSuccessful) {
+                    response.newBuilder()
+                        .removeHeader("Pragma")
+                        .header(
+                            "Cache-Control",
+                            CacheControl.Builder()
+                                .maxAge(HTTP_CACHE_MAX_AGE_SECONDS, TimeUnit.SECONDS)
+                                .build()
+                                .toString()
+                        )
+                        .build()
+                } else {
+                    response
+                }
+            }
+
+            // When offline, allow OkHttp to serve a stale cached response
+            // (up to one week old) instead of failing immediately.
+            addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .cacheControl(
+                        CacheControl.Builder()
+                            .maxStale(HTTP_CACHE_MAX_STALE_SECONDS, TimeUnit.SECONDS)
+                            .build()
+                    )
+                    .build()
+                chain.proceed(request)
+            }
+
             // Security: HTTPS-only enforcement
             // This interceptor blocks all non-HTTPS requests to prevent
             // man-in-the-middle attacks and data interception

--- a/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesContract.kt
+++ b/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesContract.kt
@@ -1,5 +1,6 @@
 package com.vamsi.worldcountriesinformation.feature.countries
 
+import com.vamsi.worldcountriesinformation.core.common.error.AppError
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIEffect
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIIntent
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIState
@@ -146,8 +147,8 @@ object CountriesContract {
         // Favorites
         val favoriteCountryCodes: Set<String> = emptySet(),
 
-        // Error state
-        val errorMessage: String? = null,
+        // Error state — UI translates to a localized string via Context.message(error)
+        val error: AppError? = null,
 
         // Cache info
         val lastUpdated: Long = 0L,
@@ -169,7 +170,7 @@ object CountriesContract {
          * True if showing data (not loading or error).
          */
         val hasData: Boolean
-            get() = countries.isNotEmpty() && !isLoading && errorMessage == null
+            get() = countries.isNotEmpty() && !isLoading && error == null
 
         /**
          * True if should show empty search results.
@@ -181,7 +182,7 @@ object CountriesContract {
          * True if should show error state.
          */
         val showError: Boolean
-            get() = errorMessage != null && !isLoading
+            get() = error != null && !isLoading
 
         /**
          * True when search history panel should be visible.
@@ -217,9 +218,9 @@ object CountriesContract {
         data class ShowToast(val message: String) : Effect
 
         /**
-         * Show an error snackbar.
+         * Show an error snackbar. The UI layer localizes the error.
          */
-        data class ShowError(val message: String) : Effect
+        data class ShowError(val error: AppError) : Effect
 
         /**
          * Show success message.

--- a/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesScreen.kt
+++ b/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesScreen.kt
@@ -93,13 +93,19 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.vamsi.snapnotify.SnapNotify
+import com.vamsi.worldcountriesinformation.core.common.error.message
 import com.vamsi.worldcountriesinformation.core.designsystem.WorldCountriesTheme
+import com.vamsi.worldcountriesinformation.core.common.R as CommonR
 import com.vamsi.worldcountriesinformation.core.designsystem.component.pressScaleEffect
 import com.vamsi.worldcountriesinformation.core.designsystem.component.rememberPressScaleInteractionSource
 import com.vamsi.worldcountriesinformation.domainmodel.Country
@@ -175,7 +181,7 @@ fun CountriesScreen(
                 }
 
                 is CountriesContract.Effect.ShowError -> {
-                    SnapNotify.showError(effect.message)
+                    SnapNotify.showError(context.message(effect.error))
                 }
 
                 is CountriesContract.Effect.ShowSuccess -> {
@@ -291,8 +297,10 @@ private fun CountriesScreenContent(
             }
 
             state.showError && state.countries.isEmpty() -> {
+                val errorContext = LocalContext.current
                 ErrorContent(
-                    message = state.errorMessage ?: "Unknown error",
+                    message = state.error?.let { errorContext.message(it) }
+                        ?: stringResource(CommonR.string.error_unknown),
                     onRetry = { onIntent(CountriesContract.Intent.RetryLoading) },
                     modifier = Modifier.padding(paddingValues)
                 )
@@ -1213,6 +1221,9 @@ private fun EmptySearchResults(
 // Previews
 // -----------------------------------------------------------------------------
 
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
 @Preview(showBackground = true, name = "Countries • List")
 @Composable
 private fun CountriesScreenPreview() {

--- a/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesScreen.kt
+++ b/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesScreen.kt
@@ -511,7 +511,7 @@ private fun ScrollableCountriesContent(
             state.searchQuery.isBlank() &&
             !state.isSearchFocused
         ) {
-            item {
+            item(key = "recently-viewed", contentType = "recently-viewed") {
                 RecentlyViewedSection(
                     countries = state.recentlyViewedCountries,
                     onCountryClick = { country ->
@@ -522,7 +522,7 @@ private fun ScrollableCountriesContent(
         }
 
         if (state.selectedRegions.isNotEmpty() || !state.isSearchActive) {
-            item {
+            item(key = "region-filters", contentType = "region-filters") {
                 RegionFilters(
                     selectedRegions = state.selectedRegions,
                     onRegionToggle = { region ->
@@ -532,7 +532,7 @@ private fun ScrollableCountriesContent(
             }
         }
 
-        item {
+        item(key = "sort-selector", contentType = "sort-selector") {
             SortSelector(
                 currentSort = state.sortOrder,
                 onSortChange = { sortOrder ->
@@ -543,7 +543,7 @@ private fun ScrollableCountriesContent(
 
         when {
             state.showEmptySearchResults -> {
-                item {
+                item(key = "empty-search", contentType = "empty-state") {
                     Box(Modifier.fillParentMaxHeight()) {
                         EmptySearchResults(
                             query = state.searchQuery,
@@ -557,7 +557,7 @@ private fun ScrollableCountriesContent(
             }
 
             state.filteredCountries.isEmpty() && !state.isLoading -> {
-                item {
+                item(key = "empty-state", contentType = "empty-state") {
                     Box(Modifier.fillParentMaxHeight()) {
                         EmptyState(modifier = Modifier.fillMaxSize())
                     }
@@ -569,7 +569,8 @@ private fun ScrollableCountriesContent(
                 // invisible (alpha 0) while flinging until scroll stopped.
                 items(
                     items = state.filteredCountries,
-                    key = { it.threeLetterCode }
+                    key = { it.threeLetterCode },
+                    contentType = { "country-card" }
                 ) { country ->
                     CountryCard(
                         country = country,

--- a/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModel.kt
+++ b/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModel.kt
@@ -1,6 +1,9 @@
 package com.vamsi.worldcountriesinformation.feature.countries
 
 import androidx.lifecycle.viewModelScope
+import com.vamsi.worldcountriesinformation.core.common.R
+import com.vamsi.worldcountriesinformation.core.common.error.AppError
+import com.vamsi.worldcountriesinformation.core.common.error.toAppError
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIViewModel
 import com.vamsi.worldcountriesinformation.core.datastore.SearchPreferences
 import com.vamsi.worldcountriesinformation.core.datastore.SearchPreferencesPort
@@ -148,14 +151,17 @@ class CountriesViewModel @Inject constructor(
                 .catch { exception ->
                     if (exception is CancellationException) throw exception
                     Timber.e(exception, "Unexpected error loading countries")
+                    val error = exception.toAppError(
+                        fallback = AppError.Generic(R.string.error_load_countries_failed)
+                    )
                     setState {
                         copy(
                             isLoading = false,
                             isRefreshing = false,
-                            errorMessage = "Failed to load countries. Please try again."
+                            error = error
                         )
                     }
-                    setEffect { CountriesContract.Effect.ShowError("Failed to load countries. Please try again.") }
+                    setEffect { CountriesContract.Effect.ShowError(error) }
                 }
                 .collect { response ->
                     response
@@ -180,38 +186,23 @@ class CountriesViewModel @Inject constructor(
                                         countries = countries
                                     ),
                                     lastUpdated = clock.millis(),
-                                    errorMessage = null
+                                    error = null
                                 )
                             }
                         }
                         .onError { exception ->
                             Timber.e(exception, "Error loading countries")
-                            val errorMessage = when {
-                                exception.message?.contains("No cached data", ignoreCase = true) == true -> {
-                                    "No cached data available. Please connect to the internet."
-                                }
-
-                                exception.message?.contains("timeout", ignoreCase = true) == true -> {
-                                    "Connection timeout. Please check your internet and try again."
-                                }
-
-                                exception.message?.contains("network", ignoreCase = true) == true -> {
-                                    "Network error. Please check your connection and try again."
-                                }
-
-                                else -> {
-                                    "Failed to load countries. Please try again."
-                                }
-                            }
-
+                            val error = exception.toAppError(
+                                fallback = AppError.Generic(R.string.error_load_countries_failed)
+                            )
                             setState {
                                 copy(
                                     isLoading = false,
                                     isRefreshing = false,
-                                    errorMessage = errorMessage
+                                    error = error
                                 )
                             }
-                            setEffect { CountriesContract.Effect.ShowError(errorMessage) }
+                            setEffect { CountriesContract.Effect.ShowError(error) }
                         }
                 }
         }
@@ -425,7 +416,7 @@ class CountriesViewModel @Inject constructor(
      * Clear error message.
      */
     private fun clearError() {
-        setState { copy(errorMessage = null) }
+        setState { copy(error = null) }
     }
 
     /**

--- a/feature/countries/src/main/res/values-de/strings.xml
+++ b/feature/countries/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="search_countries_hint">Länder suchen…</string>
+    <string name="voice_search">Sprachsuche</string>
+</resources>

--- a/feature/countries/src/main/res/values-es/strings.xml
+++ b/feature/countries/src/main/res/values-es/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="search_countries_hint">Buscar países…</string>
+    <string name="voice_search">Búsqueda por voz</string>
+</resources>

--- a/feature/countries/src/main/res/values-fr/strings.xml
+++ b/feature/countries/src/main/res/values-fr/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="search_countries_hint">Rechercher des pays…</string>
+    <string name="voice_search">Recherche vocale</string>
+</resources>

--- a/feature/countries/src/main/res/values-hi/strings.xml
+++ b/feature/countries/src/main/res/values-hi/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="search_countries_hint">देश खोजें…</string>
+    <string name="voice_search">वॉइस खोज</string>
+</resources>

--- a/feature/countries/src/test/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModelTest.kt
+++ b/feature/countries/src/test/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.vamsi.worldcountriesinformation.feature.countries
 
 import app.cash.turbine.test
+import com.vamsi.worldcountriesinformation.core.common.error.AppError
 import com.vamsi.worldcountriesinformation.core.datastore.SearchPreferencesPort
 import com.vamsi.worldcountriesinformation.domain.core.ApiResponse
 import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
@@ -169,7 +170,7 @@ class CountriesViewModelTest {
         assertEquals(emptyList<SearchHistoryEntry>(), state.searchHistory)
         assertEquals(emptySet<String>(), state.selectedRegions)
         assertEquals(SortOrder.NAME_ASC, state.sortOrder)
-        assertEquals(null, state.errorMessage)
+        assertEquals(null, state.error)
     }
 
     // ============================================================================
@@ -194,7 +195,7 @@ class CountriesViewModelTest {
             assertEquals(testCountries, state.countries)
             assertEquals(testCountries, state.filteredCountries)
             assertFalse(state.isLoading)
-            assertEquals(null, state.errorMessage)
+            assertEquals(null, state.error)
         }
     }
 
@@ -215,7 +216,7 @@ class CountriesViewModelTest {
         viewModel.state.test {
             val state = awaitItem()
             assertFalse(state.isLoading)
-            assertTrue(state.errorMessage?.contains("Network") == true)
+            assertTrue(state.error is AppError.Network)
         }
     }
 
@@ -635,7 +636,7 @@ class CountriesViewModelTest {
         advanceUntilIdle()
 
         // Then
-        assertEquals(null, viewModel.state.value.errorMessage)
+        assertEquals(null, viewModel.state.value.error)
     }
 
     @Test

--- a/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsContract.kt
+++ b/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsContract.kt
@@ -1,5 +1,7 @@
 package com.vamsi.worldcountriesinformation.feature.countrydetails
 
+import androidx.annotation.StringRes
+import com.vamsi.worldcountriesinformation.core.common.error.AppError
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIEffect
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIIntent
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIState
@@ -83,8 +85,8 @@ object CountryDetailsContract {
         // Favorite state
         val isFavorite: Boolean = false,
 
-        // Error state
-        val errorMessage: String? = null,
+        // Error state — UI translates to a localized string via Context.message(error)
+        val error: AppError? = null,
 
         // Cache info
         val lastUpdated: Long = 0L,
@@ -94,13 +96,13 @@ object CountryDetailsContract {
          * True if showing data (not loading or error).
          */
         val hasData: Boolean
-            get() = country != null && !isLoading && errorMessage == null
+            get() = country != null && !isLoading && error == null
 
         /**
          * True if should show error state.
          */
         val showError: Boolean
-            get() = errorMessage != null && !isLoading
+            get() = error != null && !isLoading
 
         /**
          * True if showing initial loading state.
@@ -126,9 +128,31 @@ object CountryDetailsContract {
         data class ShowToast(val message: String) : Effect
 
         /**
-         * Show an error snackbar.
+         * Show a localized one-time message via a string resource.
          */
-        data class ShowError(val message: String) : Effect
+        data class ShowMessage(
+            @get:StringRes val messageRes: Int,
+            val formatArgs: List<Any> = emptyList(),
+        ) : Effect
+
+        /**
+         * Show an error snackbar. The UI layer localizes the error.
+         *
+         * Either an [AppError] (preferred) or an explicit string resource
+         * with positional format args. Use the resource form for transient
+         * UI errors that don't fit the AppError taxonomy.
+         */
+        data class ShowError(
+            val error: AppError? = null,
+            @get:StringRes val messageRes: Int? = null,
+            val formatArgs: List<Any> = emptyList(),
+        ) : Effect {
+            init {
+                require(error != null || messageRes != null) {
+                    "ShowError requires either an AppError or a messageRes"
+                }
+            }
+        }
 
         /**
          * Show success message.

--- a/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsScreen.kt
+++ b/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsScreen.kt
@@ -334,25 +334,21 @@ private fun CountryDetailsScreen(
                     contentPadding = PaddingValues(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    // Country Flag
-                    item {
+                    item(key = "flag-card", contentType = "flag-card") {
                         CountryFlagCard(country = country)
                     }
 
-                    // Map with "Open in Maps" button
-                    item {
+                    item(key = "map-card", contentType = "map-card") {
                         CountryMapCard(country = country)
                     }
 
-                    // "Open in Maps" action button
                     if (country.latitude != 0.0 || country.longitude != 0.0) {
-                        item {
+                        item(key = "open-in-maps", contentType = "open-in-maps") {
                             OpenInMapsButton(onClick = onOpenInMapsClick)
                         }
                     }
 
-                    // Country Details
-                    item {
+                    item(key = "details-header", contentType = "section-header") {
                         Text(
                             text = "Country Information",
                             style = MaterialTheme.typography.titleLargeEmphasized,
@@ -360,15 +356,18 @@ private fun CountryDetailsScreen(
                         )
                     }
 
-                    items(detailsList) { detail ->
+                    items(
+                        items = detailsList,
+                        key = { it.label },
+                        contentType = { "country-detail" }
+                    ) { detail ->
                         CountryDetailItem(
                             label = detail.label,
                             value = detail.value
                         )
                     }
 
-                    // Nearby Countries section
-                    item {
+                    item(key = "nearby-countries", contentType = "nearby-countries") {
                         NearbyCountriesSection(
                             region = country.region,
                             nearbyCountries = nearbyCountries,

--- a/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsScreen.kt
+++ b/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsScreen.kt
@@ -53,17 +53,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.vamsi.snapnotify.SnapNotify
+import com.vamsi.worldcountriesinformation.core.common.error.message
 import com.vamsi.worldcountriesinformation.core.designsystem.WorldCountriesTheme
+import com.vamsi.worldcountriesinformation.core.common.R as CommonR
 import com.vamsi.worldcountriesinformation.core.designsystem.component.pressScaleEffect
 import com.vamsi.worldcountriesinformation.core.designsystem.component.rememberPressScaleInteractionSource
 import com.vamsi.worldcountriesinformation.domainmodel.Country
@@ -92,6 +100,7 @@ fun CountryDetailsRoute(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val resources = LocalResources.current
 
     // Handle effects
     LaunchedEffect(Unit) {
@@ -105,8 +114,19 @@ fun CountryDetailsRoute(
                     SnapNotify.show(effect.message)
                 }
 
+                is CountryDetailsContract.Effect.ShowMessage -> {
+                    SnapNotify.show(
+                        resources.getString(effect.messageRes, *effect.formatArgs.toTypedArray())
+                    )
+                }
+
                 is CountryDetailsContract.Effect.ShowError -> {
-                    SnapNotify.showError(effect.message)
+                    val text = effect.error?.let { resources.message(it) }
+                        ?: resources.getString(
+                            effect.messageRes!!,
+                            *effect.formatArgs.toTypedArray()
+                        )
+                    SnapNotify.showError(text)
                 }
 
                 is CountryDetailsContract.Effect.ShowSuccess -> {
@@ -188,8 +208,10 @@ private fun CountryDetailsScreenContent(
         }
 
         state.showError -> {
+            val errorContext = LocalContext.current
             CountryDetailsErrorContent(
-                message = state.errorMessage ?: "An error occurred",
+                message = state.error?.let { errorContext.message(it) }
+                    ?: stringResource(CommonR.string.error_unknown),
                 onRetry = { onIntent(CountryDetailsContract.Intent.RetryLoading(countryCode)) },
                 onNavigateBack = { onIntent(CountryDetailsContract.Intent.NavigateBack) }
             )
@@ -828,6 +850,9 @@ private fun getSampleCountry() = Country(
 
 // Previews
 @OptIn(ExperimentalMaterial3Api::class)
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
 @Preview(name = "Country Details Screen", showBackground = true)
 @Composable
 private fun CountryDetailsScreenPreview() {

--- a/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsViewModel.kt
+++ b/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsViewModel.kt
@@ -1,8 +1,11 @@
 package com.vamsi.worldcountriesinformation.feature.countrydetails
 
 import androidx.lifecycle.viewModelScope
+import com.vamsi.worldcountriesinformation.core.common.error.AppError
+import com.vamsi.worldcountriesinformation.core.common.error.toAppError
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIViewModel
 import com.vamsi.worldcountriesinformation.core.datastore.SearchPreferencesPort
+import com.vamsi.worldcountriesinformation.core.common.R as CommonR
 import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
 import com.vamsi.worldcountriesinformation.domain.core.onError
 import com.vamsi.worldcountriesinformation.domain.core.onLoading
@@ -69,14 +72,17 @@ class CountryDetailsViewModel @Inject constructor(
                 .catch { exception ->
                     if (exception is CancellationException) throw exception
                     Timber.e(exception, "Unexpected error loading country: $countryCode")
+                    val error = exception.toAppError(
+                        fallback = AppError.Generic(CommonR.string.error_load_country_details_failed)
+                    )
                     setState {
                         copy(
                             isLoading = false,
                             isRefreshing = false,
-                            errorMessage = "Failed to load country details. Please try again."
+                            error = error
                         )
                     }
-                    setEffect { CountryDetailsContract.Effect.ShowError("Failed to load country details. Please try again.") }
+                    setEffect { CountryDetailsContract.Effect.ShowError(error = error) }
                 }
                 .collect { response ->
                     response
@@ -94,7 +100,7 @@ class CountryDetailsViewModel @Inject constructor(
                                     isRefreshing = false,
                                     country = country,
                                     lastUpdated = clock.millis(),
-                                    errorMessage = null
+                                    error = null
                                 )
                             }
                             viewModelScope.launch {
@@ -107,37 +113,20 @@ class CountryDetailsViewModel @Inject constructor(
                         }
                         .onError { exception ->
                             Timber.e(exception, "Error loading country: $countryCode")
-
-                            val errorMessage = when {
-                                exception.message?.contains("No cached data", ignoreCase = true) == true -> {
-                                    "No cached data available. Please connect to the internet."
-                                }
-
-                                exception.message?.contains("not found", ignoreCase = true) == true -> {
-                                    "Country with code '$countryCode' not found"
-                                }
-
-                                exception.message?.contains("timeout", ignoreCase = true) == true -> {
-                                    "Connection timeout. Please check your internet and try again."
-                                }
-
-                                exception.message?.contains("network", ignoreCase = true) == true -> {
-                                    "Network error. Please check your connection and try again."
-                                }
-
-                                else -> {
-                                    "Failed to load country details. Please try again."
-                                }
+                            val error = when (val mapped = exception.toAppError(
+                                fallback = AppError.Generic(CommonR.string.error_load_country_details_failed)
+                            )) {
+                                is AppError.NotFound -> AppError.NotFound(identifier = countryCode)
+                                else -> mapped
                             }
-
                             setState {
                                 copy(
                                     isLoading = false,
                                     isRefreshing = false,
-                                    errorMessage = errorMessage
+                                    error = error
                                 )
                             }
-                            setEffect { CountryDetailsContract.Effect.ShowError(errorMessage) }
+                            setEffect { CountryDetailsContract.Effect.ShowError(error = error) }
                         }
                 }
         }
@@ -189,8 +178,12 @@ class CountryDetailsViewModel @Inject constructor(
      */
     private fun toggleFavorite() {
         setState { copy(isFavorite = !isFavorite) }
-        val message = if (state.value.isFavorite) "Added to favorites" else "Removed from favorites"
-        setEffect { CountryDetailsContract.Effect.ShowToast(message) }
+        val messageRes = if (state.value.isFavorite) {
+            R.string.details_added_to_favorites
+        } else {
+            R.string.details_removed_from_favorites
+        }
+        setEffect { CountryDetailsContract.Effect.ShowMessage(messageRes = messageRes) }
     }
 
     /**
@@ -212,7 +205,12 @@ class CountryDetailsViewModel @Inject constructor(
         Timber.d("Open in Maps requested for: ${country.name}")
 
         if (country.latitude == 0.0 && country.longitude == 0.0) {
-            setEffect { CountryDetailsContract.Effect.ShowError("Location data not available for ${country.name}") }
+            setEffect {
+                CountryDetailsContract.Effect.ShowError(
+                    messageRes = R.string.details_location_unavailable,
+                    formatArgs = listOf(country.name)
+                )
+            }
             return
         }
 
@@ -245,7 +243,7 @@ class CountryDetailsViewModel @Inject constructor(
      * Clear error message.
      */
     private fun clearError() {
-        setState { copy(errorMessage = null) }
+        setState { copy(error = null) }
     }
 
     /**

--- a/feature/countrydetails/src/main/res/values-de/strings.xml
+++ b/feature/countrydetails/src/main/res/values-de/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="details_location_unavailable">Standortdaten für %1$s nicht verfügbar.</string>
+    <string name="details_added_to_favorites">Zu Favoriten hinzugefügt</string>
+    <string name="details_removed_from_favorites">Aus Favoriten entfernt</string>
+</resources>

--- a/feature/countrydetails/src/main/res/values-es/strings.xml
+++ b/feature/countrydetails/src/main/res/values-es/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="details_location_unavailable">Datos de ubicación no disponibles para %1$s.</string>
+    <string name="details_added_to_favorites">Añadido a favoritos</string>
+    <string name="details_removed_from_favorites">Eliminado de favoritos</string>
+</resources>

--- a/feature/countrydetails/src/main/res/values-fr/strings.xml
+++ b/feature/countrydetails/src/main/res/values-fr/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="details_location_unavailable">Données de localisation indisponibles pour %1$s.</string>
+    <string name="details_added_to_favorites">Ajouté aux favoris</string>
+    <string name="details_removed_from_favorites">Retiré des favoris</string>
+</resources>

--- a/feature/countrydetails/src/main/res/values-hi/strings.xml
+++ b/feature/countrydetails/src/main/res/values-hi/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="details_location_unavailable">%1$s के लिए स्थान डेटा उपलब्ध नहीं है।</string>
+    <string name="details_added_to_favorites">पसंदीदा में जोड़ा गया</string>
+    <string name="details_removed_from_favorites">पसंदीदा से हटाया गया</string>
+</resources>

--- a/feature/countrydetails/src/main/res/values/strings.xml
+++ b/feature/countrydetails/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Country Details feature strings -->
+    <string name="details_location_unavailable">Location data not available for %1$s.</string>
+    <string name="details_added_to_favorites">Added to favorites</string>
+    <string name="details_removed_from_favorites">Removed from favorites</string>
+</resources>

--- a/feature/widget/src/main/res/values-de/strings.xml
+++ b/feature/widget/src/main/res/values-de/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="widget_name">Land des Tages</string>
+    <string name="widget_description">Zeige ein hervorgehobenes Land mit Details auf deinem Startbildschirm an</string>
+    <string name="widget_loading">Länderinformationen werden geladen…</string>
+    <string name="widget_error">Daten konnten nicht geladen werden</string>
+    <string name="widget_no_data">Keine Daten verfügbar</string>
+    <string name="widget_tap_to_open">Tippen, um die App zu öffnen</string>
+    <string name="country_capital">Hauptstadt</string>
+    <string name="country_region">Region</string>
+    <string name="country_population">Bevölkerung</string>
+    <string name="total_countries">Länder insgesamt</string>
+</resources>

--- a/feature/widget/src/main/res/values-es/strings.xml
+++ b/feature/widget/src/main/res/values-es/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="widget_name">País del día</string>
+    <string name="widget_description">Muestra un país destacado con detalles en tu pantalla de inicio</string>
+    <string name="widget_loading">Cargando información del país…</string>
+    <string name="widget_error">Error al cargar los datos</string>
+    <string name="widget_no_data">Sin datos disponibles</string>
+    <string name="widget_tap_to_open">Toca para abrir la app</string>
+    <string name="country_capital">Capital</string>
+    <string name="country_region">Región</string>
+    <string name="country_population">Población</string>
+    <string name="total_countries">Total de países</string>
+</resources>

--- a/feature/widget/src/main/res/values-fr/strings.xml
+++ b/feature/widget/src/main/res/values-fr/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="widget_name">Pays du jour</string>
+    <string name="widget_description">Affiche un pays mis en avant avec ses détails sur votre écran d\'accueil</string>
+    <string name="widget_loading">Chargement des informations du pays…</string>
+    <string name="widget_error">Échec du chargement des données</string>
+    <string name="widget_no_data">Aucune donnée disponible</string>
+    <string name="widget_tap_to_open">Touchez pour ouvrir l\'application</string>
+    <string name="country_capital">Capitale</string>
+    <string name="country_region">Région</string>
+    <string name="country_population">Population</string>
+    <string name="total_countries">Total des pays</string>
+</resources>

--- a/feature/widget/src/main/res/values-hi/strings.xml
+++ b/feature/widget/src/main/res/values-hi/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="widget_name">आज का देश</string>
+    <string name="widget_description">अपनी होम स्क्रीन पर विवरण के साथ एक विशेष देश दिखाएँ</string>
+    <string name="widget_loading">देश की जानकारी लोड हो रही है…</string>
+    <string name="widget_error">डेटा लोड करने में विफल</string>
+    <string name="widget_no_data">कोई डेटा उपलब्ध नहीं</string>
+    <string name="widget_tap_to_open">ऐप खोलने के लिए टैप करें</string>
+    <string name="country_capital">राजधानी</string>
+    <string name="country_region">क्षेत्र</string>
+    <string name="country_population">जनसंख्या</string>
+    <string name="total_countries">कुल देश</string>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ okhttp = "5.3.2"
 retrofit-kotlinx-serialization = "1.0.0"
 
 # Image Loading
-coil = "2.7.0"
+coil = "3.3.0"
 
 # Coroutines
 coroutines = "1.10.2"
@@ -153,8 +153,9 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 
 # Image Loading
-coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+coil = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 
 # Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -192,6 +193,7 @@ hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testi
 # Gradle Plugins (for build-logic)
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-composeCompilerGradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmarkMacro" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,6 @@ retrofit-kotlinx-serialization = "1.0.0"
 
 # Image Loading
 coil = "2.7.0"
-glide = "5.0.7"
 
 # Coroutines
 coroutines = "1.10.2"
@@ -156,8 +155,6 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor",
 # Image Loading
 coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
-glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
 
 # Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary

Bundles Sprint 2 work into a single PR per `docs/IMPROVEMENT_PLAN.md`.

### Architecture
- **3.3 AppError sealed model** in `core/common` with `Context.message()` / `Resources.message()` extensions. ViewModels now expose typed errors instead of raw English strings.
- **3.1 MVIViewModel base** centralizes state/intent/effect plumbing, removing per-ViewModel boilerplate.

### Performance
- **4.1 Cache pre-warm**: `CachePreloader` warms the Room countries table on cold start from `Application.onCreate`.
- **4.5 Macrobenchmarks**: `ScrollBenchmark` (list fling) and `DetailsOpenBenchmark` (tap → details → back) with `FrameTimingMetric`.
- **4.7 Compose stability sweep**: `compose_compiler_config.conf` wired through the convention plugin marks domain models (Country, Currency, Language, etc.) as stable.

### Dependencies
- **2.2 Coil 3.3.0**: group `io.coil-kt` → `io.coil-kt.coil3`, packages `coil` → `coil3`. Added `coil-network-okhttp`.

### UX
- **5.9 Localization expansion**: es, fr, de, hi `values-*` directories across `app`, `core/common`, `feature/countries`, `feature/countrydetails`, `feature/widget`.
- **5.10 Accessibility previews**: `PreviewLightDark`, `PreviewFontScale`, `PreviewScreenSizes` on key screens.

### Hygiene
- `app_name` marked `translatable="false"`.
- Resource lookups inside Compose effects switched from `LocalContext` to `LocalResources` to satisfy `LocalContextGetResourceValueCall` lint.

### Deferred to Sprint 3
- **3.4 Country split** — touches every repo/mapper/UseCase/ViewModel/widget/test. Too risky to bundle here; warrants its own PR.

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `./gradlew lintDebug` — BUILD SUCCESSFUL (zero new errors)
- [ ] Macrobenchmarks: `./gradlew :benchmark:connectedBenchmarkAndroidTest` on a physical device
- [ ] Spot-check translated strings render correctly in `es`/`fr`/`de`/`hi` locales
- [ ] Verify TalkBack flow on country list and details screens