### PR TITLE
feat(sprint3): country split, smart search, compare, deep links

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     // Feature modules (bring in UI, ViewModels, domain dependencies transitively)
     implementation(project(":feature:countries"))
     implementation(project(":feature:countrydetails"))
+    implementation(project(":feature:compare"))
     implementation(project(":feature:settings"))
     implementation(project(":feature:widget"))
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,35 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Deep link: https://worldcountries.vamsi.dev/country/{code} -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="worldcountries.vamsi.dev"
+                    android:pathPrefix="/country/" />
+                <data
+                    android:scheme="http"
+                    android:host="worldcountries.vamsi.dev"
+                    android:pathPrefix="/country/" />
+            </intent-filter>
+
+            <!-- Deep link: wci://country/{code} (custom scheme for sharing) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="wci"
+                    android:host="country" />
+            </intent-filter>
         </activity>
 
         <meta-data

--- a/app/src/main/java/com/vamsi/worldcountriesinformation/ui/MainActivity.kt
+++ b/app/src/main/java/com/vamsi/worldcountriesinformation/ui/MainActivity.kt
@@ -102,18 +102,34 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Handles deep link navigation from widgets and other sources
+     * Handles deep link navigation from widgets, ACTION_VIEW intents (https/wci),
+     * and other sources.
      */
     private fun handleDeepLink(intent: Intent, navigator: Navigator) {
-        val countryCode = intent.getStringExtra(EXTRA_COUNTRY_CODE)
-        if (countryCode != null) {
-            Timber.d("Deep link: Navigating to country details for code: $countryCode")
-            try {
-                // Navigate to country details, clearing any intermediate screens
-                navigator.navigateAndClear(CountryDetailsRoute(countryCode))
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to navigate to country details")
-            }
+        val countryCode = resolveCountryCode(intent) ?: return
+        Timber.d("Deep link: Navigating to country details for code: $countryCode")
+        try {
+            navigator.navigateAndClear(CountryDetailsRoute(countryCode))
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to navigate to country details")
         }
+    }
+
+    /**
+     * Resolves a country code from an inbound intent, supporting widget extras
+     * and ACTION_VIEW deep-link URIs (https + wci scheme).
+     */
+    private fun resolveCountryCode(intent: Intent): String? {
+        intent.getStringExtra(EXTRA_COUNTRY_CODE)?.takeIf { it.isNotBlank() }?.let { return it.uppercase() }
+
+        if (intent.action != Intent.ACTION_VIEW) return null
+        val data = intent.data ?: return null
+        val raw = when (data.scheme?.lowercase()) {
+            "https", "http" -> data.lastPathSegment
+            "wci" -> data.host?.takeIf { it.equals("country", ignoreCase = true) }
+                ?.let { data.lastPathSegment ?: data.pathSegments.firstOrNull() }
+            else -> null
+        }
+        return raw?.takeIf { it.length == 3 && it.all { ch -> ch.isLetter() } }?.uppercase()
     }
 }

--- a/app/src/main/java/com/vamsi/worldcountriesinformation/ui/compose/navigation/Navigation.kt
+++ b/app/src/main/java/com/vamsi/worldcountriesinformation/ui/compose/navigation/Navigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
+import com.vamsi.worldcountriesinformation.core.navigation.CompareRoute
 import com.vamsi.worldcountriesinformation.core.navigation.CountriesRoute
 import com.vamsi.worldcountriesinformation.core.navigation.CountryDetailsRoute
 import com.vamsi.worldcountriesinformation.core.navigation.NavigationState
@@ -11,6 +12,7 @@ import com.vamsi.worldcountriesinformation.core.navigation.Navigator
 import com.vamsi.worldcountriesinformation.core.navigation.SettingsRoute
 import com.vamsi.worldcountriesinformation.core.navigation.rememberNavigationState
 import com.vamsi.worldcountriesinformation.core.navigation.toEntries
+import com.vamsi.worldcountriesinformation.feature.compare.CompareRoute as CompareScreen
 import com.vamsi.worldcountriesinformation.feature.countries.CountriesScreen
 import com.vamsi.worldcountriesinformation.feature.settings.SettingsScreen
 import com.vamsi.worldcountriesinformation.feature.countrydetails.CountryDetailsRoute as CountryDetailsScreen
@@ -75,7 +77,18 @@ fun WorldCountriesNavigation(
                 },
                 onNavigateToSettings = {
                     navigator.navigate(SettingsRoute)
-                }
+                },
+                onNavigateToCompare = { codes ->
+                    navigator.navigate(CompareRoute(codes.joinToString(",")))
+                },
+            )
+        }
+
+        // Compare Screen
+        entry<CompareRoute> { key ->
+            CompareScreen(
+                countryCodes = key.codes,
+                onNavigateBack = { navigator.goBack() },
             )
         }
 

--- a/core/model/src/main/java/com/vamsi/worldcountriesinformation/domainmodel/CountrySummary.kt
+++ b/core/model/src/main/java/com/vamsi/worldcountriesinformation/domainmodel/CountrySummary.kt
@@ -1,0 +1,19 @@
+package com.vamsi.worldcountriesinformation.domainmodel
+
+/**
+ * Light, list-friendly projection of a country. Excludes detail-only fields
+ * (languages, currencies, calling code) so list, search, suggestions, recents,
+ * favorites, and widget paths don't pull heavy data into memory.
+ *
+ * Detail screens should resolve the full [Country] via the repository.
+ */
+data class CountrySummary(
+    val name: String,
+    val capital: String,
+    val region: String,
+    val population: Int,
+    val twoLetterCode: String,
+    val threeLetterCode: String,
+    val latitude: Double,
+    val longitude: Double,
+)

--- a/core/navigation/src/main/kotlin/com/vamsi/worldcountriesinformation/core/navigation/NavigationRoutes.kt
+++ b/core/navigation/src/main/kotlin/com/vamsi/worldcountriesinformation/core/navigation/NavigationRoutes.kt
@@ -91,3 +91,20 @@ data object SettingsRoute : NavKey
  */
 @Serializable
 data class CountryDetailsRoute(val countryCode: String) : NavKey
+
+/**
+ * Compare countries screen - shows two or three countries side-by-side.
+ *
+ * **Parameters:**
+ * - [countryCodes]: Three-letter codes joined by comma (e.g. "USA,IND,JPN").
+ *
+ * **Example:**
+ * ```kotlin
+ * navigator.navigate(CompareRoute("USA,CAN"))
+ * ```
+ */
+@Serializable
+data class CompareRoute(val countryCodes: String) : NavKey {
+    val codes: List<String>
+        get() = countryCodes.split(',').filter { it.isNotBlank() }
+}

--- a/data/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/data/countries/mapper/EntityMapper.kt
+++ b/data/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/data/countries/mapper/EntityMapper.kt
@@ -4,6 +4,7 @@ import com.vamsi.worldcountriesinformation.core.database.entity.CountryEntity
 import com.vamsi.worldcountriesinformation.core.database.entity.CurrencyEntity
 import com.vamsi.worldcountriesinformation.core.database.entity.LanguageEntity
 import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.Currency
 import com.vamsi.worldcountriesinformation.domainmodel.Language
 
@@ -45,6 +46,36 @@ fun CurrencyEntity.toDomain(): Currency {
 
 fun List<CountryEntity>.toDomainList(): List<Country> {
     return this.map { it.toDomain() }
+}
+
+// Entity to Summary (light projection)
+fun CountryEntity.toSummary(): CountrySummary {
+    return CountrySummary(
+        name = name,
+        capital = capital,
+        region = region,
+        population = population,
+        twoLetterCode = twoLetterCode,
+        threeLetterCode = threeLetterCode,
+        latitude = latitude,
+        longitude = longitude,
+    )
+}
+
+fun List<CountryEntity>.toSummaryList(): List<CountrySummary> = map { it.toSummary() }
+
+// Domain (full) -> Summary
+fun Country.toSummary(): CountrySummary {
+    return CountrySummary(
+        name = name,
+        capital = capital,
+        region = region,
+        population = population,
+        twoLetterCode = twoLetterCode,
+        threeLetterCode = threeLetterCode,
+        latitude = latitude,
+        longitude = longitude,
+    )
 }
 
 // Domain to Entity

--- a/data/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/data/countries/repository/CountriesRepositoryImpl.kt
+++ b/data/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/data/countries/repository/CountriesRepositoryImpl.kt
@@ -9,11 +9,13 @@ import com.vamsi.worldcountriesinformation.data.countries.mapper.toCountry // v3
 import com.vamsi.worldcountriesinformation.data.countries.mapper.toDomain
 import com.vamsi.worldcountriesinformation.data.countries.mapper.toDomainList
 import com.vamsi.worldcountriesinformation.data.countries.mapper.toEntityList
+import com.vamsi.worldcountriesinformation.data.countries.mapper.toSummaryList
 import com.vamsi.worldcountriesinformation.domain.core.ApiResponse
 import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
 import com.vamsi.worldcountriesinformation.domain.countries.CountriesRepository
 import com.vamsi.worldcountriesinformation.domain.countries.CountryCacheSnapshot
 import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -152,7 +154,7 @@ class CountriesRepositoryImpl @Inject constructor(
      * @see CachePolicy for detailed policy descriptions
      * @see emitAll for reactive Flow transformation
      */
-    override fun getCountries(policy: CachePolicy): Flow<ApiResponse<List<Country>>> {
+    override fun getCountries(policy: CachePolicy): Flow<ApiResponse<List<CountrySummary>>> {
         return flow {
             // Emit loading state
             emit(ApiResponse.Loading)
@@ -162,12 +164,12 @@ class CountriesRepositoryImpl @Inject constructor(
                 val cachedCountries = countryDao.getAllCountriesOnce()
                 if (cachedCountries.isNotEmpty()) {
                     Timber.d("CACHE_ONLY: Emitting ${cachedCountries.size} cached countries")
-                    emit(ApiResponse.Success(cachedCountries.toDomainList()))
+                    emit(ApiResponse.Success(cachedCountries.toSummaryList()))
 
                     // Start reactive observation for any future database changes
                     emitAll(
                         countryDao.getAllCountries().map { entities ->
-                            ApiResponse.Success(entities.toDomainList())
+                            ApiResponse.Success(entities.toSummaryList())
                         }
                     )
                 } else {
@@ -214,7 +216,7 @@ class CountriesRepositoryImpl @Inject constructor(
             if (shouldEmitCache && hasCache) {
                 val cachedCountries = loadCachedSnapshotOnce()
                 Timber.d("${policy.name}: Emitting ${cachedCountries.size} cached countries")
-                emit(ApiResponse.Success(cachedCountries.toDomainList()))
+                emit(ApiResponse.Success(cachedCountries.toSummaryList()))
             }
 
             // Step 4: Determine if network fetch is needed
@@ -281,7 +283,7 @@ class CountriesRepositoryImpl @Inject constructor(
             Timber.d("${policy.name}: Starting reactive database observation")
             emitAll(
                 countryDao.getAllCountries().map { entities ->
-                    ApiResponse.Success(entities.toDomainList())
+                    ApiResponse.Success(entities.toSummaryList())
                 }
             )
         }
@@ -488,21 +490,21 @@ class CountriesRepositoryImpl @Inject constructor(
         return null
     }
 
-    override fun getCountriesFlow(): Flow<List<Country>> {
+    override fun getCountriesFlow(): Flow<List<CountrySummary>> {
         return countryDao.getAllCountries().map { entities ->
-            entities.toDomainList()
+            entities.toSummaryList()
         }
     }
 
-    override fun searchCountries(query: String): Flow<List<Country>> {
+    override fun searchCountries(query: String): Flow<List<CountrySummary>> {
         return countryDao.searchCountries(query).map { entities ->
-            entities.toDomainList()
+            entities.toSummaryList()
         }
     }
 
-    override fun getCountriesByRegion(region: String): Flow<List<Country>> {
+    override fun getCountriesByRegion(region: String): Flow<List<CountrySummary>> {
         return countryDao.getCountriesByRegion(region).map { entities ->
-            entities.toDomainList()
+            entities.toSummaryList()
         }
     }
 
@@ -547,7 +549,7 @@ class CountriesRepositoryImpl @Inject constructor(
         countryDao.deleteAllCountries()
     }
 
-    private suspend fun FlowCollector<ApiResponse<List<Country>>>.handleCountriesListNetworkFailure(
+    private suspend fun FlowCollector<ApiResponse<List<CountrySummary>>>.handleCountriesListNetworkFailure(
         policy: CachePolicy,
         hasCache: Boolean,
         cachedCountries: List<CountryEntity>,
@@ -562,7 +564,7 @@ class CountriesRepositoryImpl @Inject constructor(
             CachePolicy.NETWORK_FIRST -> {
                 if (hasCache) {
                     Timber.d("NETWORK_FIRST: Network failed, falling back to cached data")
-                    emit(ApiResponse.Success(cachedCountries.toDomainList()))
+                    emit(ApiResponse.Success(cachedCountries.toSummaryList()))
                 } else {
                     Timber.w("NETWORK_FIRST: Network failed and no cache available")
                     emit(ApiResponse.Error(exception))

--- a/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/CountriesRepository.kt
+++ b/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/CountriesRepository.kt
@@ -3,6 +3,7 @@ package com.vamsi.worldcountriesinformation.domain.countries
 import com.vamsi.worldcountriesinformation.domain.core.ApiResponse
 import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
 import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -104,7 +105,7 @@ interface CountriesRepository {
      * @see CachePolicy for detailed policy descriptions
      * @since 2.4.0 (added cache policy support)
      */
-    fun getCountries(policy: CachePolicy = CachePolicy.CACHE_FIRST): Flow<ApiResponse<List<Country>>>
+    fun getCountries(policy: CachePolicy = CachePolicy.CACHE_FIRST): Flow<ApiResponse<List<CountrySummary>>>
     
     /**
      * Retrieves a single country by its three-letter ISO code.
@@ -190,7 +191,7 @@ interface CountriesRepository {
      *
      * @since 2.0.0
      */
-    fun getCountriesFlow(): Flow<List<Country>>
+    fun getCountriesFlow(): Flow<List<CountrySummary>>
     
     /**
      * Searches countries by name with reactive updates.
@@ -249,7 +250,7 @@ interface CountriesRepository {
      * @since 2.0.0
      * @see SearchCountriesUseCase for a more feature-rich search implementation
      */
-    fun searchCountries(query: String): Flow<List<Country>>
+    fun searchCountries(query: String): Flow<List<CountrySummary>>
     
     /**
      * Retrieves countries filtered by region with reactive updates.
@@ -316,7 +317,7 @@ interface CountriesRepository {
      * @since 2.0.0
      * @see GetCountriesByRegionUseCase for a more feature-rich implementation
      */
-    fun getCountriesByRegion(region: String): Flow<List<Country>>
+    fun getCountriesByRegion(region: String): Flow<List<CountrySummary>>
     
     /**
      * Forces a refresh of country data from the network.

--- a/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/FilteredSearchCountriesUseCase.kt
+++ b/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/FilteredSearchCountriesUseCase.kt
@@ -1,6 +1,6 @@
 package com.vamsi.worldcountriesinformation.domain.countries
 
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.SearchFilters
 import com.vamsi.worldcountriesinformation.domainmodel.SortOrder
 import kotlinx.coroutines.flow.Flow
@@ -93,7 +93,7 @@ class FilteredSearchCountriesUseCase @Inject constructor(
     operator fun invoke(
         query: String,
         filters: SearchFilters
-    ): Flow<List<Country>> {
+    ): Flow<List<CountrySummary>> {
         return searchCountriesUseCase(query)
             .map { countries ->
                 applyFiltersAndSort(countries, filters)
@@ -111,9 +111,9 @@ class FilteredSearchCountriesUseCase @Inject constructor(
      * @return Filtered and sorted list of countries
      */
     fun applyFiltersAndSort(
-        countries: List<Country>,
+        countries: List<CountrySummary>,
         filters: SearchFilters
-    ): List<Country> {
+    ): List<CountrySummary> {
         var filtered = countries
 
         // Apply region filter
@@ -140,9 +140,9 @@ class FilteredSearchCountriesUseCase @Inject constructor(
      * @return Sorted list of countries
      */
     private fun applySortOrder(
-        countries: List<Country>,
+        countries: List<CountrySummary>,
         sortOrder: SortOrder
-    ): List<Country> {
+    ): List<CountrySummary> {
         return when (sortOrder) {
             SortOrder.NAME_ASC -> countries.sortedBy { it.name }
             SortOrder.NAME_DESC -> countries.sortedByDescending { it.name }
@@ -205,8 +205,8 @@ class GenerateSearchSuggestionsUseCase @Inject constructor() {
      */
     operator fun invoke(
         query: String,
-        allCountries: List<Country>,
-        maxSuggestions: Int = 5
+        allCountries: List<CountrySummary>,
+        maxSuggestions: Int = 5,
     ): List<String> {
         if (query.isBlank()) return emptyList()
 

--- a/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/GetCountriesByRegionUseCase.kt
+++ b/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/GetCountriesByRegionUseCase.kt
@@ -1,6 +1,6 @@
 package com.vamsi.worldcountriesinformation.domain.countries
 
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -227,7 +227,7 @@ class GetCountriesByRegionUseCase @Inject constructor(
      *
      * @throws IllegalArgumentException if region is empty
      */
-    operator fun invoke(region: String): Flow<List<Country>> {
+    operator fun invoke(region: String): Flow<List<CountrySummary>> {
         require(region.isNotBlank()) {
             "Region cannot be empty. Valid regions: ${VALID_REGIONS.joinToString()}"
         }

--- a/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/GetCountriesUseCase.kt
+++ b/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/GetCountriesUseCase.kt
@@ -4,7 +4,7 @@ import com.vamsi.worldcountriesinformation.domain.core.ApiResponse
 import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
 import com.vamsi.worldcountriesinformation.domain.core.FlowUseCase
 import com.vamsi.worldcountriesinformation.domain.di.IoDispatcher
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -61,7 +61,7 @@ import javax.inject.Inject
 open class GetCountriesUseCase @Inject constructor(
     private val repository: CountriesRepository,
     @IoDispatcher ioDispatcher: CoroutineDispatcher
-) : FlowUseCase<CachePolicy, List<Country>>(ioDispatcher) {
+) : FlowUseCase<CachePolicy, List<CountrySummary>>(ioDispatcher) {
 
     /**
      * Executes the use case to retrieve all countries.
@@ -69,7 +69,7 @@ open class GetCountriesUseCase @Inject constructor(
      * @param parameters Cache policy to use (default: CACHE_FIRST)
      * @return Flow of [ApiResponse] containing list of countries
      */
-    override fun execute(parameters: CachePolicy): Flow<ApiResponse<List<Country>>> {
+    override fun execute(parameters: CachePolicy): Flow<ApiResponse<List<CountrySummary>>> {
         return repository.getCountries(policy = parameters)
     }
 }

--- a/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/GetNearbyCountriesUseCase.kt
+++ b/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/GetNearbyCountriesUseCase.kt
@@ -1,6 +1,6 @@
 package com.vamsi.worldcountriesinformation.domain.countries
 
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -71,7 +71,7 @@ class GetNearbyCountriesUseCase @Inject constructor(
      * @return Flow emitting filtered list of nearby countries, sorted alphabetically
      * @throws IllegalArgumentException if region is blank
      */
-    operator fun invoke(region: String, excludeCountryCode: String): Flow<List<Country>> {
+    operator fun invoke(region: String, excludeCountryCode: String): Flow<List<CountrySummary>> {
         require(region.isNotBlank()) {
             "Region cannot be empty. Provide a valid region to find nearby countries."
         }

--- a/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/SearchCountriesUseCase.kt
+++ b/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/countries/SearchCountriesUseCase.kt
@@ -1,6 +1,6 @@
 package com.vamsi.worldcountriesinformation.domain.countries
 
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -184,7 +184,7 @@ class SearchCountriesUseCase @Inject constructor(
      *         Never completes (continuous observation)
      *
      */
-    operator fun invoke(query: String): Flow<List<Country>> {
+    operator fun invoke(query: String): Flow<List<CountrySummary>> {
         // Normalize query
         val normalizedQuery = query.trim().lowercase()
 

--- a/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/search/SearchRanker.kt
+++ b/domain/src/main/java/com/vamsi/worldcountriesinformation/domain/search/SearchRanker.kt
@@ -1,0 +1,137 @@
+package com.vamsi.worldcountriesinformation.domain.search
+
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
+import javax.inject.Inject
+import kotlin.math.max
+
+/**
+ * Ranks countries against a search query using a layered scoring strategy:
+ *
+ * 1. Exact name match
+ * 2. Prefix match on name or capital
+ * 3. Substring match on name, capital, or three-letter code
+ * 4. Fuzzy match (Jaro-Winkler) above a threshold
+ * 5. Boosts for recently viewed and favorited countries
+ *
+ * Pure Kotlin so it is fully unit-testable and free of Android deps.
+ */
+class SearchRanker @Inject constructor() {
+
+    fun rank(
+        query: String,
+        countries: List<CountrySummary>,
+        recentCodes: Set<String> = emptySet(),
+        favoriteCodes: Set<String> = emptySet(),
+    ): List<CountrySummary> {
+        if (countries.isEmpty()) return emptyList()
+        val normalizedQuery = query.trim().lowercase()
+        if (normalizedQuery.isBlank()) {
+            return countries.sortedWith(
+                compareByDescending<CountrySummary> { it.threeLetterCode in favoriteCodes }
+                    .thenByDescending { it.threeLetterCode in recentCodes }
+                    .thenBy { it.name },
+            )
+        }
+        return countries
+            .map { it to scoreCountry(it, normalizedQuery, recentCodes, favoriteCodes) }
+            .filter { (_, score) -> score > 0.0 }
+            .sortedWith(
+                compareByDescending<Pair<CountrySummary, Double>> { it.second }
+                    .thenBy { it.first.name },
+            )
+            .map { it.first }
+    }
+
+    private fun scoreCountry(
+        country: CountrySummary,
+        query: String,
+        recentCodes: Set<String>,
+        favoriteCodes: Set<String>,
+    ): Double {
+        val name = country.name.lowercase()
+        val capital = country.capital.lowercase()
+        val code3 = country.threeLetterCode.lowercase()
+        val code2 = country.twoLetterCode.lowercase()
+
+        var score = when {
+            name == query -> EXACT_MATCH
+            code2 == query || code3 == query -> EXACT_MATCH - 1.0
+            name.startsWith(query) -> PREFIX_NAME
+            capital.startsWith(query) -> PREFIX_CAPITAL
+            name.contains(query) -> SUBSTRING_NAME
+            capital.contains(query) -> SUBSTRING_CAPITAL
+            code3.contains(query) -> SUBSTRING_CODE
+            else -> {
+                val jw = max(jaroWinkler(name, query), jaroWinkler(capital, query))
+                if (jw >= FUZZY_THRESHOLD) FUZZY_BASE * jw else 0.0
+            }
+        }
+
+        if (score > 0.0) {
+            if (country.threeLetterCode in recentCodes) score += RECENT_BOOST
+            if (country.threeLetterCode in favoriteCodes) score += FAVORITE_BOOST
+        }
+        return score
+    }
+
+    /**
+     * Jaro-Winkler similarity in [0.0, 1.0]. Tuned for short strings such as
+     * country names, with the standard prefix scaling factor (0.1, capped at 4).
+     */
+    internal fun jaroWinkler(s1: String, s2: String): Double {
+        if (s1.isEmpty() || s2.isEmpty()) return 0.0
+        if (s1 == s2) return 1.0
+
+        val matchDistance = max(s1.length, s2.length) / 2 - 1
+        val s1Matches = BooleanArray(s1.length)
+        val s2Matches = BooleanArray(s2.length)
+        var matches = 0
+        for (i in s1.indices) {
+            val start = maxOf(0, i - matchDistance)
+            val end = minOf(i + matchDistance + 1, s2.length)
+            for (j in start until end) {
+                if (s2Matches[j]) continue
+                if (s1[i] != s2[j]) continue
+                s1Matches[i] = true
+                s2Matches[j] = true
+                matches++
+                break
+            }
+        }
+        if (matches == 0) return 0.0
+
+        var transpositions = 0
+        var k = 0
+        for (i in s1.indices) {
+            if (!s1Matches[i]) continue
+            while (!s2Matches[k]) k++
+            if (s1[i] != s2[k]) transpositions++
+            k++
+        }
+        transpositions /= 2
+
+        val m = matches.toDouble()
+        val jaro = (m / s1.length + m / s2.length + (m - transpositions) / m) / 3.0
+
+        var prefixLength = 0
+        val limit = minOf(4, s1.length, s2.length)
+        for (i in 0 until limit) {
+            if (s1[i] == s2[i]) prefixLength++ else break
+        }
+        return jaro + prefixLength * PREFIX_SCALE * (1.0 - jaro)
+    }
+
+    private companion object {
+        const val EXACT_MATCH = 1000.0
+        const val PREFIX_NAME = 500.0
+        const val PREFIX_CAPITAL = 400.0
+        const val SUBSTRING_NAME = 250.0
+        const val SUBSTRING_CAPITAL = 200.0
+        const val SUBSTRING_CODE = 180.0
+        const val FUZZY_BASE = 100.0
+        const val FUZZY_THRESHOLD = 0.85
+        const val RECENT_BOOST = 40.0
+        const val FAVORITE_BOOST = 80.0
+        const val PREFIX_SCALE = 0.1
+    }
+}

--- a/domain/src/test/java/com/vamsi/worldcountriesinformation/domain/countries/GenerateSearchSuggestionsUseCaseTest.kt
+++ b/domain/src/test/java/com/vamsi/worldcountriesinformation/domain/countries/GenerateSearchSuggestionsUseCaseTest.kt
@@ -1,8 +1,6 @@
 package com.vamsi.worldcountriesinformation.domain.countries
 
-import com.vamsi.worldcountriesinformation.domainmodel.Country
-import com.vamsi.worldcountriesinformation.domainmodel.Currency
-import com.vamsi.worldcountriesinformation.domainmodel.Language
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -22,19 +20,16 @@ class GenerateSearchSuggestionsUseCaseTest {
         createCountry("Uruguay", "Montevideo")
     )
 
-    private fun createCountry(name: String, capital: String): Country {
-        return Country(
+    private fun createCountry(name: String, capital: String): CountrySummary {
+        return CountrySummary(
             name = name,
             capital = capital,
-            languages = listOf(Language("English", "en")),
             twoLetterCode = name.take(2).uppercase(),
             threeLetterCode = name.take(3).uppercase(),
             population = 1000000,
             region = "TestRegion",
-            currencies = listOf(Currency("TestCurrency", "TST", "$")),
-            callingCode = "+1",
             latitude = 0.0,
-            longitude = 0.0
+            longitude = 0.0,
         )
     }
 

--- a/domain/src/test/java/com/vamsi/worldcountriesinformation/domain/countries/GetCountriesUseCaseTest.kt
+++ b/domain/src/test/java/com/vamsi/worldcountriesinformation/domain/countries/GetCountriesUseCaseTest.kt
@@ -46,7 +46,7 @@ class GetCountriesUseCaseTest {
     @Test
     fun `countries list is returned by repository successfully`() = runTest(testDispatcher) {
         // Given
-        val expectedCountries = TestData.getCountries()
+        val expectedCountries = TestData.getCountrySummaries()
         val expectedResult = flowOf(ApiResponse.Success(expectedCountries))
         coEvery { countriesRepository.getCountries() } returns expectedResult
 

--- a/domain/src/test/java/com/vamsi/worldcountriesinformation/domain/search/SearchRankerTest.kt
+++ b/domain/src/test/java/com/vamsi/worldcountriesinformation/domain/search/SearchRankerTest.kt
@@ -1,0 +1,120 @@
+package com.vamsi.worldcountriesinformation.domain.search
+
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SearchRankerTest {
+
+    private lateinit var ranker: SearchRanker
+
+    private val unitedStates = country("United States", "Washington D.C.", "US", "USA")
+    private val unitedKingdom = country("United Kingdom", "London", "GB", "GBR")
+    private val unitedArab = country("United Arab Emirates", "Abu Dhabi", "AE", "ARE")
+    private val canada = country("Canada", "Ottawa", "CA", "CAN")
+    private val ukraine = country("Ukraine", "Kyiv", "UA", "UKR")
+    private val australia = country("Australia", "Canberra", "AU", "AUS")
+
+    private val all = listOf(unitedStates, unitedKingdom, unitedArab, canada, ukraine, australia)
+
+    @Before
+    fun setup() {
+        ranker = SearchRanker()
+    }
+
+    @Test
+    fun `blank query returns alphabetical order`() {
+        val result = ranker.rank("", all)
+        assertEquals(
+            listOf("Australia", "Canada", "Ukraine", "United Arab Emirates", "United Kingdom", "United States"),
+            result.map { it.name },
+        )
+    }
+
+    @Test
+    fun `blank query promotes favorites then recents`() {
+        val result = ranker.rank(
+            query = "",
+            countries = all,
+            recentCodes = setOf("CAN"),
+            favoriteCodes = setOf("UKR"),
+        )
+        assertEquals("Ukraine", result.first().name)
+        assertEquals("Canada", result[1].name)
+    }
+
+    @Test
+    fun `prefix on name ranks ahead of capital substring`() {
+        // Australia's capital "Canberra" contains "can"; Canada starts with "can".
+        val result = ranker.rank("can", all)
+        assertEquals(canada, result.first())
+        assertTrue(result.indexOf(canada) < result.indexOf(australia))
+    }
+
+    @Test
+    fun `exact name match wins`() {
+        val result = ranker.rank("canada", all)
+        assertEquals(canada, result.first())
+    }
+
+    @Test
+    fun `recent boost reorders ties`() {
+        val withoutBoost = ranker.rank("united", all)
+        val withBoost = ranker.rank(
+            query = "united",
+            countries = all,
+            recentCodes = setOf("USA"),
+        )
+        // Without boost: alphabetical tiebreak among the three "United*" prefix matches.
+        assertEquals(unitedArab, withoutBoost.first())
+        // With recent boost: USA jumps ahead of the alphabetical winner.
+        assertEquals(unitedStates, withBoost.first())
+    }
+
+    @Test
+    fun `favorite boost outranks recent`() {
+        val result = ranker.rank(
+            query = "united",
+            countries = all,
+            recentCodes = setOf("USA"),
+            favoriteCodes = setOf("GBR"),
+        )
+        assertEquals(unitedKingdom, result.first())
+    }
+
+    @Test
+    fun `fuzzy match catches typos`() {
+        val result = ranker.rank("canda", all)
+        assertEquals(canada, result.first())
+    }
+
+    @Test
+    fun `non-matching candidates are dropped`() {
+        val result = ranker.rank("zzz", all)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `three letter code match returns country`() {
+        val result = ranker.rank("usa", all)
+        assertEquals(unitedStates, result.first())
+    }
+
+    private fun country(
+        name: String,
+        capital: String,
+        twoLetter: String,
+        threeLetter: String,
+    ) = CountrySummary(
+        name = name,
+        capital = capital,
+        twoLetterCode = twoLetter,
+        threeLetterCode = threeLetter,
+        population = 1,
+        region = "Test",
+        latitude = 0.0,
+        longitude = 0.0,
+    )
+}

--- a/feature/compare/build.gradle.kts
+++ b/feature/compare/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("worldcountries.android.library")
+    id("worldcountries.android.hilt")
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "com.vamsi.worldcountriesinformation.feature.compare"
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(project(":core:common"))
+    implementation(project(":core:designsystem"))
+    implementation(project(":core:navigation"))
+    implementation(project(":core:model"))
+    implementation(project(":domain"))
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.hilt.navigation.compose)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+
+    implementation(libs.timber)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
+    testImplementation(project(":tests-shared"))
+}

--- a/feature/compare/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/compare/CompareContract.kt
+++ b/feature/compare/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/compare/CompareContract.kt
@@ -1,0 +1,34 @@
+package com.vamsi.worldcountriesinformation.feature.compare
+
+import com.vamsi.worldcountriesinformation.core.common.error.AppError
+import com.vamsi.worldcountriesinformation.core.common.mvi.MVIEffect
+import com.vamsi.worldcountriesinformation.core.common.mvi.MVIIntent
+import com.vamsi.worldcountriesinformation.core.common.mvi.MVIState
+import com.vamsi.worldcountriesinformation.domainmodel.Country
+
+/**
+ * MVI contract for the compare-countries feature.
+ */
+object CompareContract {
+
+    sealed interface Intent : MVIIntent {
+        data class LoadCountries(val codes: List<String>) : Intent
+        data class RetryLoading(val codes: List<String>) : Intent
+        data object NavigateBack : Intent
+    }
+
+    data class State(
+        val isLoading: Boolean = false,
+        val countries: List<Country> = emptyList(),
+        val error: AppError? = null,
+    ) : MVIState {
+        val showError: Boolean get() = error != null && !isLoading
+        val showLoading: Boolean get() = isLoading && countries.isEmpty()
+        val hasData: Boolean get() = countries.size >= 2 && !isLoading && error == null
+    }
+
+    sealed interface Effect : MVIEffect {
+        data object NavigateBack : Effect
+        data class ShowError(val error: AppError) : Effect
+    }
+}

--- a/feature/compare/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/compare/CompareScreen.kt
+++ b/feature/compare/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/compare/CompareScreen.kt
@@ -1,0 +1,288 @@
+package com.vamsi.worldcountriesinformation.feature.compare
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vamsi.worldcountriesinformation.core.common.error.message
+import com.vamsi.worldcountriesinformation.core.designsystem.WorldCountriesTheme
+import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.Currency
+import com.vamsi.worldcountriesinformation.domainmodel.Language
+import kotlinx.coroutines.flow.collectLatest
+import java.text.NumberFormat
+import java.util.Locale
+
+@Composable
+fun CompareRoute(
+    countryCodes: List<String>,
+    onNavigateBack: () -> Unit,
+    viewModel: CompareViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is CompareContract.Effect.NavigateBack -> onNavigateBack()
+                is CompareContract.Effect.ShowError -> Unit
+            }
+        }
+    }
+
+    LaunchedEffect(countryCodes) {
+        viewModel.processIntent(CompareContract.Intent.LoadCountries(countryCodes))
+    }
+
+    CompareScreen(
+        state = state,
+        onRetry = { viewModel.processIntent(CompareContract.Intent.RetryLoading(countryCodes)) },
+        onNavigateBack = { viewModel.processIntent(CompareContract.Intent.NavigateBack) },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CompareScreen(
+    state: CompareContract.State,
+    onRetry: () -> Unit,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.compare_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.compare_navigate_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            when {
+                state.showLoading -> LoadingState()
+                state.showError -> ErrorState(
+                    message = state.error?.let { LocalContextMessage(it) }
+                        ?: stringResource(R.string.compare_error_load_failed),
+                    onRetry = onRetry,
+                )
+
+                state.hasData -> CompareTable(state.countries)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocalContextMessage(error: com.vamsi.worldcountriesinformation.core.common.error.AppError): String {
+    val resources = androidx.compose.ui.platform.LocalResources.current
+    return resources.message(error)
+}
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(48.dp))
+    }
+}
+
+@Composable
+private fun ErrorState(
+    message: String,
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Button(onClick = onRetry, modifier = Modifier.padding(top = 16.dp)) {
+            Text(stringResource(R.string.compare_retry))
+        }
+    }
+}
+
+private data class CompareRow(val label: String, val values: List<String>)
+
+@Composable
+private fun CompareTable(countries: List<Country>) {
+    val rows = remember(countries) { buildRows(countries) }
+    val scrollState = rememberScrollState()
+    val columnWidth = 160.dp
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(scrollState)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(vertical = 12.dp, horizontal = 16.dp),
+        ) {
+            HeaderCell(text = "", width = columnWidth)
+            countries.forEach { country ->
+                HeaderCell(text = country.name, width = columnWidth)
+            }
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(vertical = 8.dp),
+        ) {
+            items(rows, key = { it.label }) { row ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(scrollState)
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                ) {
+                    BodyCell(text = row.label, width = columnWidth, emphasized = true)
+                    row.values.forEach { value ->
+                        BodyCell(text = value, width = columnWidth)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderCell(text: String, width: androidx.compose.ui.unit.Dp) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+        modifier = Modifier.width(width),
+    )
+}
+
+@Composable
+private fun BodyCell(text: String, width: androidx.compose.ui.unit.Dp, emphasized: Boolean = false) {
+    Text(
+        text = text,
+        style = if (emphasized) {
+            MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+        } else {
+            MaterialTheme.typography.bodyMedium
+        },
+        modifier = Modifier.width(width),
+    )
+}
+
+private fun buildRows(countries: List<Country>): List<CompareRow> {
+    val nf = NumberFormat.getNumberInstance(Locale.getDefault())
+    return listOf(
+        CompareRow(
+            label = "Capital",
+            values = countries.map { it.capital.ifEmpty { "—" } },
+        ),
+        CompareRow(
+            label = "Region",
+            values = countries.map { it.region.ifEmpty { "—" } },
+        ),
+        CompareRow(
+            label = "Population",
+            values = countries.map { nf.format(it.population) },
+        ),
+        CompareRow(
+            label = "Languages",
+            values = countries.map { country ->
+                country.languages
+                    .mapNotNull { it.name }
+                    .joinToString(", ")
+                    .ifEmpty { "—" }
+            },
+        ),
+        CompareRow(
+            label = "Currencies",
+            values = countries.map { country ->
+                country.currencies
+                    .mapNotNull { c -> c.name?.let { name -> c.code?.let { "$name ($it)" } ?: name } }
+                    .joinToString(", ")
+                    .ifEmpty { "—" }
+            },
+        ),
+        CompareRow(
+            label = "Calling code",
+            values = countries.map { it.callingCode.ifEmpty { "—" } },
+        ),
+    )
+}
+
+@Preview(name = "Compare screen", showBackground = true)
+@Composable
+private fun CompareScreenPreview() {
+    WorldCountriesTheme {
+        CompareScreen(
+            state = CompareContract.State(
+                countries = listOf(sample("United States", "USA"), sample("Canada", "CAN")),
+            ),
+            onRetry = {},
+            onNavigateBack = {},
+        )
+    }
+}
+
+private fun sample(name: String, code: String) = Country(
+    name = name,
+    capital = "Capital",
+    languages = listOf(Language(name = "English")),
+    twoLetterCode = code.take(2),
+    threeLetterCode = code,
+    population = 1_000_000,
+    region = "Region",
+    currencies = listOf(Currency(code = "XYZ", name = "Sample", symbol = "$")),
+    callingCode = "+1",
+    latitude = 0.0,
+    longitude = 0.0,
+)

--- a/feature/compare/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/compare/CompareViewModel.kt
+++ b/feature/compare/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/compare/CompareViewModel.kt
@@ -1,0 +1,89 @@
+package com.vamsi.worldcountriesinformation.feature.compare
+
+import androidx.lifecycle.viewModelScope
+import com.vamsi.worldcountriesinformation.core.common.error.AppError
+import com.vamsi.worldcountriesinformation.core.common.error.toAppError
+import com.vamsi.worldcountriesinformation.core.common.mvi.MVIViewModel
+import com.vamsi.worldcountriesinformation.domain.core.ApiResponse
+import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
+import com.vamsi.worldcountriesinformation.domain.countries.CountryByCodeParams
+import com.vamsi.worldcountriesinformation.domain.countries.GetCountryByCodeUseCase
+import com.vamsi.worldcountriesinformation.domainmodel.Country
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class CompareViewModel @Inject constructor(
+    private val getCountryByCodeUseCase: GetCountryByCodeUseCase,
+) : MVIViewModel<CompareContract.Intent, CompareContract.State, CompareContract.Effect>(
+    initialState = CompareContract.State(),
+) {
+
+    override fun handleIntent(intent: CompareContract.Intent) {
+        when (intent) {
+            is CompareContract.Intent.LoadCountries -> loadCountries(intent.codes)
+            is CompareContract.Intent.RetryLoading -> loadCountries(intent.codes)
+            is CompareContract.Intent.NavigateBack -> setEffect { CompareContract.Effect.NavigateBack }
+        }
+    }
+
+    private fun loadCountries(codes: List<String>) {
+        if (codes.size < 2) {
+            val error = AppError.Generic(R.string.compare_error_min_selection)
+            setState { copy(isLoading = false, error = error) }
+            setEffect { CompareContract.Effect.ShowError(error) }
+            return
+        }
+
+        viewModelScope.launch {
+            setState { copy(isLoading = true, error = null) }
+            try {
+                val countries = codes
+                    .map { code ->
+                        async { fetchCountry(code) }
+                    }
+                    .awaitAll()
+                    .filterNotNull()
+
+                if (countries.size < 2) {
+                    val error = AppError.Generic(R.string.compare_error_load_failed)
+                    setState { copy(isLoading = false, error = error) }
+                    setEffect { CompareContract.Effect.ShowError(error) }
+                } else {
+                    setState {
+                        copy(
+                            isLoading = false,
+                            countries = countries,
+                            error = null,
+                        )
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Compare: failed to load countries: $codes")
+                val error = e.toAppError(
+                    fallback = AppError.Generic(R.string.compare_error_load_failed),
+                )
+                setState { copy(isLoading = false, error = error) }
+                setEffect { CompareContract.Effect.ShowError(error) }
+            }
+        }
+    }
+
+    private suspend fun fetchCountry(code: String): Country? {
+        val response = getCountryByCodeUseCase(
+            CountryByCodeParams(code, CachePolicy.CACHE_FIRST),
+        ).firstOrNull { it !is ApiResponse.Loading }
+        return when (response) {
+            is ApiResponse.Success -> response.data
+            else -> null
+        }
+    }
+}

--- a/feature/compare/src/main/res/values/strings.xml
+++ b/feature/compare/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+    <string name="compare_title">Compare countries</string>
+    <string name="compare_navigate_back">Navigate back</string>
+    <string name="compare_loading">Loading…</string>
+    <string name="compare_retry">Retry</string>
+    <string name="compare_error_min_selection">Pick at least 2 countries to compare.</string>
+    <string name="compare_error_load_failed">Couldn\'t load all selected countries. Try again.</string>
+    <string name="compare_label_capital">Capital</string>
+    <string name="compare_label_region">Region</string>
+    <string name="compare_label_population">Population</string>
+    <string name="compare_label_languages">Languages</string>
+    <string name="compare_label_currencies">Currencies</string>
+    <string name="compare_label_calling_code">Calling code</string>
+</resources>

--- a/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesContract.kt
+++ b/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesContract.kt
@@ -4,7 +4,7 @@ import com.vamsi.worldcountriesinformation.core.common.error.AppError
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIEffect
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIIntent
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIState
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.RecentlyViewedEntry
 import com.vamsi.worldcountriesinformation.domainmodel.SearchHistoryEntry
 import com.vamsi.worldcountriesinformation.domainmodel.SortOrder
@@ -109,6 +109,26 @@ object CountriesContract {
          * User cleared the entire history list.
          */
         data object ClearSearchHistory : Intent
+
+        /**
+         * User toggled compare-selection mode (e.g. via long-press).
+         */
+        data object ToggleSelectionMode : Intent
+
+        /**
+         * User added or removed a country from the current compare selection.
+         */
+        data class ToggleCompareSelection(val countryCode: String) : Intent
+
+        /**
+         * User cleared the active compare selection.
+         */
+        data object ClearCompareSelection : Intent
+
+        /**
+         * User confirmed the current compare selection.
+         */
+        data object ConfirmCompare : Intent
     }
 
     // ============================================================================
@@ -126,8 +146,8 @@ object CountriesContract {
         val isRefreshing: Boolean = false,
 
         // Data
-        val countries: List<Country> = emptyList(),
-        val filteredCountries: List<Country> = emptyList(),
+        val countries: List<CountrySummary> = emptyList(),
+        val filteredCountries: List<CountrySummary> = emptyList(),
 
         // Search
         val searchQuery: String = "",
@@ -138,7 +158,7 @@ object CountriesContract {
 
         // Recently viewed
         val recentlyViewedEntries: List<RecentlyViewedEntry> = emptyList(),
-        val recentlyViewedCountries: List<Country> = emptyList(),
+        val recentlyViewedCountries: List<CountrySummary> = emptyList(),
 
         // Filters
         val selectedRegions: Set<String> = emptySet(),
@@ -152,7 +172,28 @@ object CountriesContract {
 
         // Cache info
         val lastUpdated: Long = 0L,
+
+        // Compare-selection mode
+        val isSelecting: Boolean = false,
+        val compareSelection: List<String> = emptyList(),
     ) : MVIState {
+
+        /**
+         * True when at least 2 (and at most [MAX_COMPARE]) countries are selected.
+         */
+        val canConfirmCompare: Boolean
+            get() = compareSelection.size in MIN_COMPARE..MAX_COMPARE
+
+        /**
+         * True when the cap has been hit and additional selections will be ignored.
+         */
+        val compareSelectionAtCap: Boolean
+            get() = compareSelection.size >= MAX_COMPARE
+
+        companion object {
+            const val MIN_COMPARE = 2
+            const val MAX_COMPARE = 3
+        }
 
         /**
          * True if there are any active filters.
@@ -226,5 +267,10 @@ object CountriesContract {
          * Show success message.
          */
         data class ShowSuccess(val message: String) : Effect
+
+        /**
+         * Navigate to the compare screen with the selected three-letter codes.
+         */
+        data class NavigateToCompare(val codes: List<String>) : Effect
     }
 }

--- a/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesScreen.kt
+++ b/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -108,9 +110,7 @@ import com.vamsi.worldcountriesinformation.core.designsystem.WorldCountriesTheme
 import com.vamsi.worldcountriesinformation.core.common.R as CommonR
 import com.vamsi.worldcountriesinformation.core.designsystem.component.pressScaleEffect
 import com.vamsi.worldcountriesinformation.core.designsystem.component.rememberPressScaleInteractionSource
-import com.vamsi.worldcountriesinformation.domainmodel.Country
-import com.vamsi.worldcountriesinformation.domainmodel.Currency
-import com.vamsi.worldcountriesinformation.domainmodel.Language
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.Regions
 import com.vamsi.worldcountriesinformation.domainmodel.SearchHistoryEntry
 import com.vamsi.worldcountriesinformation.domainmodel.SortOrder
@@ -141,6 +141,7 @@ internal fun extractSpokenText(resultCode: Int, results: List<String>?): String?
 fun CountriesScreen(
     onNavigateToDetails: (String) -> Unit,
     onNavigateToSettings: () -> Unit = {},
+    onNavigateToCompare: (List<String>) -> Unit = {},
     viewModel: CountriesViewModel = hiltViewModel(),
 ) {
     // Collect state
@@ -186,6 +187,10 @@ fun CountriesScreen(
 
                 is CountriesContract.Effect.ShowSuccess -> {
                     SnapNotify.showSuccess(effect.message)
+                }
+
+                is CountriesContract.Effect.NavigateToCompare -> {
+                    onNavigateToCompare(effect.codes)
                 }
             }
         }
@@ -240,30 +245,63 @@ private fun CountriesScreenContent(
     Scaffold(
         containerColor = androidx.compose.ui.graphics.Color.Transparent,
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        "Countries",
-                        style = MaterialTheme.typography.titleLargeEmphasized
-                    )
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
-                    titleContentColor = MaterialTheme.colorScheme.onSurface
-                ),
-                actions = {
-                    if (state.hasActiveFilters) {
+            if (state.isSelecting) {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = "${state.compareSelection.size} selected",
+                            style = MaterialTheme.typography.titleLargeEmphasized,
+                        )
+                    },
+                    navigationIcon = {
                         IconButton(
-                            onClick = { onIntent(CountriesContract.Intent.ClearFilters) }
+                            onClick = { onIntent(CountriesContract.Intent.ClearCompareSelection) }
                         ) {
-                            Icon(Icons.Default.FilterList, "Clear filters")
+                            Icon(
+                                imageVector = Icons.Default.Clear,
+                                contentDescription = "Cancel compare selection",
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.95f),
+                        titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                    actions = {
+                        TextButton(
+                            onClick = { onIntent(CountriesContract.Intent.ConfirmCompare) },
+                            enabled = state.canConfirmCompare,
+                        ) {
+                            Text("Compare")
+                        }
+                    },
+                )
+            } else {
+                TopAppBar(
+                    title = {
+                        Text(
+                            "Countries",
+                            style = MaterialTheme.typography.titleLargeEmphasized
+                        )
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
+                        titleContentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    actions = {
+                        if (state.hasActiveFilters) {
+                            IconButton(
+                                onClick = { onIntent(CountriesContract.Intent.ClearFilters) }
+                            ) {
+                                Icon(Icons.Default.FilterList, "Clear filters")
+                            }
+                        }
+                        IconButton(onClick = onNavigateToSettings) {
+                            Icon(Icons.Default.Settings, "Settings")
                         }
                     }
-                    IconButton(onClick = onNavigateToSettings) {
-                        Icon(Icons.Default.Settings, "Settings")
-                    }
-                }
-            )
+                )
+            }
         },
         floatingActionButton = {
             val showFab = !state.shouldShowSearchHistory && scrolledPastTop
@@ -580,11 +618,26 @@ private fun ScrollableCountriesContent(
                     key = { it.threeLetterCode },
                     contentType = { "country-card" }
                 ) { country ->
+                    val code = country.threeLetterCode
+                    val isSelectedForCompare = state.compareSelection.contains(code)
                     CountryCard(
                         country = country,
-                        isFavorite = state.favoriteCountryCodes.contains(country.threeLetterCode),
-                        onClick = { onIntent(CountriesContract.Intent.CountryClicked(country.threeLetterCode)) },
-                        onFavoriteClick = { onIntent(CountriesContract.Intent.ToggleFavorite(country.threeLetterCode)) }
+                        isFavorite = state.favoriteCountryCodes.contains(code),
+                        isSelecting = state.isSelecting,
+                        isSelectedForCompare = isSelectedForCompare,
+                        onClick = {
+                            if (state.isSelecting) {
+                                onIntent(CountriesContract.Intent.ToggleCompareSelection(code))
+                            } else {
+                                onIntent(CountriesContract.Intent.CountryClicked(code))
+                            }
+                        },
+                        onLongClick = {
+                            onIntent(CountriesContract.Intent.ToggleCompareSelection(code))
+                        },
+                        onFavoriteClick = {
+                            onIntent(CountriesContract.Intent.ToggleFavorite(code))
+                        },
                     )
                 }
             }
@@ -698,8 +751,8 @@ private fun SortOrder.humanReadableLabel(): String = when (this) {
 
 @Composable
 private fun RecentlyViewedSection(
-    countries: List<Country>,
-    onCountryClick: (Country) -> Unit,
+    countries: List<CountrySummary>,
+    onCountryClick: (CountrySummary) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -724,7 +777,7 @@ private fun RecentlyViewedSection(
 
 @Composable
 private fun RecentlyViewedCard(
-    country: Country,
+    country: CountrySummary,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -789,7 +842,7 @@ private fun RecentlyViewedCard(
 @Composable
 private fun AlphabetJumpIndexWithVisibility(
     visible: Boolean,
-    countries: List<Country>,
+    countries: List<CountrySummary>,
     listState: LazyListState,
     headerItemCount: Int,
     modifier: Modifier = Modifier,
@@ -810,7 +863,7 @@ private fun AlphabetJumpIndexWithVisibility(
 
 @Composable
 private fun AlphabetJumpIndex(
-    countries: List<Country>,
+    countries: List<CountrySummary>,
     listState: LazyListState,
     headerItemCount: Int = 0,
     modifier: Modifier = Modifier,
@@ -846,7 +899,7 @@ private fun AlphabetJumpIndex(
     }
 }
 
-private fun buildAlphabetIndexMap(countries: List<Country>): Map<String, Int> {
+private fun buildAlphabetIndexMap(countries: List<CountrySummary>): Map<String, Int> {
     val letterToIndex = LinkedHashMap<String, Int>()
     countries.forEachIndexed { index, country ->
         val letter = country.name.trim().firstOrNull()?.uppercaseChar()
@@ -860,13 +913,17 @@ private fun buildAlphabetIndexMap(countries: List<Country>): Map<String, Int> {
     return letterToIndex
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun CountryCard(
-    country: Country,
+    country: CountrySummary,
     isFavorite: Boolean,
     onClick: () -> Unit,
     onFavoriteClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isSelecting: Boolean = false,
+    isSelectedForCompare: Boolean = false,
+    onLongClick: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val flagResourceName = "${country.twoLetterCode.lowercase()}_flag"
@@ -878,20 +935,26 @@ private fun CountryCard(
         )
     }
     val interactionSource = rememberPressScaleInteractionSource()
+    val containerColor = if (isSelectedForCompare) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
 
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(
+            .combinedClickable(
                 interactionSource = interactionSource,
                 indication = null,
-                onClick = onClick
+                onClick = onClick,
+                onLongClick = onLongClick,
             )
             .pressScaleEffect(interactionSource),
         shape = MaterialTheme.shapes.medium,
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = containerColor
         )
     ) {
         Row(
@@ -1269,30 +1332,24 @@ private fun CountriesScreenSearchHistoryPreview() {
 }
 
 private val PreviewCountries = listOf(
-    Country(
+    CountrySummary(
         name = "Canada",
         capital = "Ottawa",
-        languages = listOf(Language(name = "English")),
         twoLetterCode = "CA",
         threeLetterCode = "CAN",
         population = 38_000_000,
         region = "Americas",
-        currencies = listOf(Currency(code = "CAD", name = "Canadian Dollar", symbol = "$")),
-        callingCode = "+1",
         latitude = 56.0,
-        longitude = -106.0
+        longitude = -106.0,
     ),
-    Country(
+    CountrySummary(
         name = "Japan",
         capital = "Tokyo",
-        languages = listOf(Language(name = "Japanese")),
         twoLetterCode = "JP",
         threeLetterCode = "JPN",
         population = 125_000_000,
         region = "Asia",
-        currencies = listOf(Currency(code = "JPY", name = "Yen", symbol = "¥")),
-        callingCode = "+81",
         latitude = 36.0,
-        longitude = 138.0
-    )
+        longitude = 138.0,
+    ),
 )

--- a/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModel.kt
+++ b/feature/countries/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModel.kt
@@ -16,7 +16,8 @@ import com.vamsi.worldcountriesinformation.domain.countries.GenerateSearchSugges
 import com.vamsi.worldcountriesinformation.domain.countries.GetCountriesUseCase
 import com.vamsi.worldcountriesinformation.domain.countries.SearchCountriesUseCase
 import com.vamsi.worldcountriesinformation.domain.search.SearchFiltersUseCase
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domain.search.SearchRanker
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.RecentlyViewedEntry
 import com.vamsi.worldcountriesinformation.domainmodel.SearchFilters
 import com.vamsi.worldcountriesinformation.domainmodel.SortOrder
@@ -52,6 +53,7 @@ class CountriesViewModel @Inject constructor(
     private val suggestionsUseCase: GenerateSearchSuggestionsUseCase,
     private val searchPreferencesDataSource: SearchPreferencesPort,
     private val searchFiltersUseCase: SearchFiltersUseCase,
+    private val searchRanker: SearchRanker,
     private val clock: Clock,
 ) : MVIViewModel<CountriesContract.Intent, CountriesContract.State, CountriesContract.Effect>(
     initialState = CountriesContract.State()
@@ -137,6 +139,10 @@ class CountriesViewModel @Inject constructor(
             is CountriesContract.Intent.SearchSuggestionSelected -> selectSearchQuery(intent.suggestion)
             is CountriesContract.Intent.DeleteSearchHistoryItem -> deleteSearchHistoryEntry(intent.query)
             is CountriesContract.Intent.ClearSearchHistory -> clearSearchHistory()
+            is CountriesContract.Intent.ToggleSelectionMode -> toggleSelectionMode()
+            is CountriesContract.Intent.ToggleCompareSelection -> toggleCompareSelection(intent.countryCode)
+            is CountriesContract.Intent.ClearCompareSelection -> clearCompareSelection()
+            is CountriesContract.Intent.ConfirmCompare -> confirmCompare()
         }
     }
 
@@ -268,7 +274,7 @@ class CountriesViewModel @Inject constructor(
                             Timber.e(exception, "Search error for query: $query")
                         }
                         .collect { results ->
-                            setState { copy(filteredCountries = results) }
+                            setState { copy(filteredCountries = rankResults(query, results)) }
                         }
                 } else {
                     // Use basic search
@@ -277,7 +283,7 @@ class CountriesViewModel @Inject constructor(
                             Timber.e(exception, "Search error for query: $query")
                         }
                         .collect { results ->
-                            setState { copy(filteredCountries = results) }
+                            setState { copy(filteredCountries = rankResults(query, results)) }
                         }
                 }
             }
@@ -419,17 +425,69 @@ class CountriesViewModel @Inject constructor(
         setState { copy(error = null) }
     }
 
+    private fun toggleSelectionMode() {
+        setState {
+            val nextSelecting = !isSelecting
+            copy(
+                isSelecting = nextSelecting,
+                compareSelection = if (nextSelecting) compareSelection else emptyList(),
+            )
+        }
+    }
+
+    private fun toggleCompareSelection(countryCode: String) {
+        val normalized = countryCode.uppercase()
+        setState {
+            val current = compareSelection
+            val next = when {
+                current.contains(normalized) -> current - normalized
+                current.size >= CountriesContract.State.MAX_COMPARE -> current
+                else -> current + normalized
+            }
+            copy(
+                isSelecting = next.isNotEmpty() || isSelecting,
+                compareSelection = next,
+            )
+        }
+    }
+
+    private fun clearCompareSelection() {
+        setState { copy(isSelecting = false, compareSelection = emptyList()) }
+    }
+
+    private fun confirmCompare() {
+        val codes = state.value.compareSelection
+        if (codes.size < CountriesContract.State.MIN_COMPARE) return
+        setEffect { CountriesContract.Effect.NavigateToCompare(codes) }
+    }
+
     /**
      * Apply filters and sorting to countries list.
      */
-    private fun applyFiltersAndSort(countries: List<Country>, filters: SearchFilters): List<Country> {
+    private fun applyFiltersAndSort(countries: List<CountrySummary>, filters: SearchFilters): List<CountrySummary> {
         return filteredSearchUseCase.applyFiltersAndSort(countries, filters)
+    }
+
+    private fun rankResults(query: String, results: List<CountrySummary>): List<CountrySummary> {
+        if (query.isBlank()) return results
+        val recentCodes = state.value.recentlyViewedEntries
+            .map { it.countryCode.uppercase() }
+            .toSet()
+        val favoriteCodes = state.value.favoriteCountryCodes
+            .map { it.uppercase() }
+            .toSet()
+        return searchRanker.rank(
+            query = query,
+            countries = results,
+            recentCodes = recentCodes,
+            favoriteCodes = favoriteCodes,
+        )
     }
 
     private fun mapRecentlyViewedCountries(
         entries: List<RecentlyViewedEntry>,
-        countries: List<Country>,
-    ): List<Country> {
+        countries: List<CountrySummary>,
+    ): List<CountrySummary> {
         if (entries.isEmpty() || countries.isEmpty()) return emptyList()
         val countryMap = countries.associateBy { it.threeLetterCode.uppercase() }
         return entries.mapNotNull { entry ->

--- a/feature/countries/src/test/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModelTest.kt
+++ b/feature/countries/src/test/kotlin/com/vamsi/worldcountriesinformation/feature/countries/CountriesViewModelTest.kt
@@ -9,9 +9,7 @@ import com.vamsi.worldcountriesinformation.domain.countries.FilteredSearchCountr
 import com.vamsi.worldcountriesinformation.domain.countries.GenerateSearchSuggestionsUseCase
 import com.vamsi.worldcountriesinformation.domain.countries.GetCountriesUseCase
 import com.vamsi.worldcountriesinformation.domain.countries.SearchCountriesUseCase
-import com.vamsi.worldcountriesinformation.domainmodel.Country
-import com.vamsi.worldcountriesinformation.domainmodel.Currency
-import com.vamsi.worldcountriesinformation.domainmodel.Language
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.SearchHistoryEntry
 import com.vamsi.worldcountriesinformation.domainmodel.SortOrder
 import io.mockk.Runs
@@ -68,45 +66,36 @@ class CountriesViewModelTest {
         Clock.fixed(Instant.ofEpochMilli(1_718_452_800_000L), ZoneOffset.UTC)
 
     private val testCountries = listOf(
-        Country(
+        CountrySummary(
             name = "United States",
             capital = "Washington D.C.",
-            languages = listOf(Language("English", "en")),
             twoLetterCode = "US",
             threeLetterCode = "USA",
             population = 331002651,
             region = "Americas",
-            currencies = listOf(Currency("US Dollar", "USD", "$")),
-            callingCode = "+1",
             latitude = 38.0,
-            longitude = -97.0
+            longitude = -97.0,
         ),
-        Country(
+        CountrySummary(
             name = "Canada",
             capital = "Ottawa",
-            languages = listOf(Language("English", "en"), Language("French", "fr")),
             twoLetterCode = "CA",
             threeLetterCode = "CAN",
             population = 37742154,
             region = "Americas",
-            currencies = listOf(Currency("Canadian Dollar", "CAD", "$")),
-            callingCode = "+1",
             latitude = 56.0,
-            longitude = -106.0
+            longitude = -106.0,
         ),
-        Country(
+        CountrySummary(
             name = "United Kingdom",
             capital = "London",
-            languages = listOf(Language("English", "en")),
             twoLetterCode = "GB",
             threeLetterCode = "GBR",
             population = 67886011,
             region = "Europe",
-            currencies = listOf(Currency("British Pound", "GBP", "£")),
-            callingCode = "+44",
             latitude = 54.0,
-            longitude = -2.0
-        )
+            longitude = -2.0,
+        ),
     )
 
     @Before
@@ -143,6 +132,7 @@ class CountriesViewModelTest {
             suggestionsUseCase = suggestionsUseCase,
             searchPreferencesDataSource = searchPreferencesDataSource,
             searchFiltersUseCase = searchFiltersUseCase,
+            searchRanker = com.vamsi.worldcountriesinformation.domain.search.SearchRanker(),
             clock = testClock,
         )
     }
@@ -162,8 +152,8 @@ class CountriesViewModelTest {
 
         // Then
         val state = viewModel.state.value
-        assertEquals(emptyList<Country>(), state.countries)
-        assertEquals(emptyList<Country>(), state.filteredCountries)
+        assertEquals(emptyList<CountrySummary>(), state.countries)
+        assertEquals(emptyList<CountrySummary>(), state.filteredCountries)
         assertEquals("", state.searchQuery)
         assertFalse(state.isSearchActive)
         assertFalse(state.isSearchFocused)

--- a/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsContract.kt
+++ b/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsContract.kt
@@ -6,6 +6,7 @@ import com.vamsi.worldcountriesinformation.core.common.mvi.MVIEffect
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIIntent
 import com.vamsi.worldcountriesinformation.core.common.mvi.MVIState
 import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 
 /**
  * MVI Contract for Country Details feature.
@@ -79,7 +80,7 @@ object CountryDetailsContract {
         val country: Country? = null,
 
         // Nearby countries
-        val nearbyCountries: List<Country> = emptyList(),
+        val nearbyCountries: List<CountrySummary> = emptyList(),
         val isLoadingNearby: Boolean = false,
 
         // Favorite state

--- a/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsScreen.kt
+++ b/feature/countrydetails/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/countrydetails/CountryDetailsScreen.kt
@@ -75,6 +75,7 @@ import com.vamsi.worldcountriesinformation.core.common.R as CommonR
 import com.vamsi.worldcountriesinformation.core.designsystem.component.pressScaleEffect
 import com.vamsi.worldcountriesinformation.core.designsystem.component.rememberPressScaleInteractionSource
 import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.Currency
 import com.vamsi.worldcountriesinformation.domainmodel.Language
 import com.vamsi.worldcountriesinformation.feature.countrydetails.component.CountryDetailsShimmer
@@ -254,7 +255,8 @@ private fun CountryDetailsScreenContent(
 private fun CountryDetailsScreen(
     country: Country,
     isFavorite: Boolean,
-    nearbyCountries: List<Country> = emptyList(),
+    nearbyCountries: List<CountrySummary> = emptyList(),
+
     isLoadingNearby: Boolean = false,
     onNavigateBack: () -> Unit,
     isRefreshing: Boolean = false,
@@ -560,7 +562,7 @@ private fun OpenInMapsButton(
 @Composable
 private fun NearbyCountriesSection(
     region: String,
-    nearbyCountries: List<Country>,
+    nearbyCountries: List<CountrySummary>,
     isLoading: Boolean,
     onCountryClick: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -627,7 +629,7 @@ private fun NearbyCountriesSection(
  */
 @Composable
 private fun NearbyCountryCard(
-    country: Country,
+    country: CountrySummary,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -934,43 +936,34 @@ private fun CountryDetailsErrorContentPreview() {
 }
 
 private fun getSampleNearbyCountries() = listOf(
-    Country(
+    CountrySummary(
         name = "Canada",
         capital = "Ottawa",
         region = "Americas",
         population = 38005238,
         twoLetterCode = "CA",
         threeLetterCode = "CAN",
-        callingCode = "+1",
-        currencies = listOf(Currency(code = "CAD", name = "Canadian dollar", symbol = "$")),
-        languages = listOf(Language(name = "English"), Language(name = "French")),
         latitude = 56.1304,
-        longitude = -106.3468
+        longitude = -106.3468,
     ),
-    Country(
+    CountrySummary(
         name = "Mexico",
         capital = "Mexico City",
         region = "Americas",
         population = 128932753,
         twoLetterCode = "MX",
         threeLetterCode = "MEX",
-        callingCode = "+52",
-        currencies = listOf(Currency(code = "MXN", name = "Mexican peso", symbol = "$")),
-        languages = listOf(Language(name = "Spanish")),
         latitude = 23.6345,
-        longitude = -102.5528
+        longitude = -102.5528,
     ),
-    Country(
+    CountrySummary(
         name = "Brazil",
         capital = "Brasília",
         region = "Americas",
         population = 212559417,
         twoLetterCode = "BR",
         threeLetterCode = "BRA",
-        callingCode = "+55",
-        currencies = listOf(Currency(code = "BRL", name = "Brazilian real", symbol = "R$")),
-        languages = listOf(Language(name = "Portuguese")),
         latitude = -14.235,
-        longitude = -51.9253
-    )
+        longitude = -51.9253,
+    ),
 )

--- a/feature/widget/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/widget/CountryWidget.kt
+++ b/feature/widget/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/widget/CountryWidget.kt
@@ -279,7 +279,7 @@ private fun SuccessState(
  * Small widget layout - Shows only flag and country name
  */
 @Composable
-private fun SmallWidgetLayout(country: com.vamsi.worldcountriesinformation.domainmodel.Country, context: Context) {
+private fun SmallWidgetLayout(country: com.vamsi.worldcountriesinformation.domainmodel.CountrySummary, context: Context) {
     Column(
         modifier = GlanceModifier
             .fillMaxSize()
@@ -314,7 +314,7 @@ private fun SmallWidgetLayout(country: com.vamsi.worldcountriesinformation.domai
  */
 @Composable
 private fun MediumWidgetLayout(
-    country: com.vamsi.worldcountriesinformation.domainmodel.Country,
+    country: com.vamsi.worldcountriesinformation.domainmodel.CountrySummary,
     widgetData: WidgetData,
     context: Context,
 ) {
@@ -383,7 +383,7 @@ private fun MediumWidgetLayout(
  */
 @Composable
 private fun LargeWidgetLayout(
-    country: com.vamsi.worldcountriesinformation.domainmodel.Country,
+    country: com.vamsi.worldcountriesinformation.domainmodel.CountrySummary,
     widgetData: WidgetData,
     context: Context,
 ) {

--- a/feature/widget/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/widget/data/WidgetData.kt
+++ b/feature/widget/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/widget/data/WidgetData.kt
@@ -1,12 +1,12 @@
 package com.vamsi.worldcountriesinformation.feature.widget.data
 
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 
 /**
  * Data class representing the state of the country widget
  */
 data class WidgetData(
-    val featuredCountry: Country? = null,
+    val featuredCountry: CountrySummary? = null,
     val totalCountries: Int = 0,
     val isLoading: Boolean = true,
     val error: String? = null,

--- a/feature/widget/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/widget/data/WidgetDataSource.kt
+++ b/feature/widget/src/main/kotlin/com/vamsi/worldcountriesinformation/feature/widget/data/WidgetDataSource.kt
@@ -4,7 +4,7 @@ import com.vamsi.worldcountriesinformation.domain.core.ApiResponse
 import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
 import com.vamsi.worldcountriesinformation.domain.countries.GetCountriesUseCase
 import com.vamsi.worldcountriesinformation.domain.di.IoDispatcher
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.firstOrNull
@@ -100,7 +100,7 @@ class WidgetDataSource @Inject constructor(
     }
 }
 
-internal fun pickFeaturedCountry(countries: List<Country>): Country? {
+internal fun pickFeaturedCountry(countries: List<CountrySummary>): CountrySummary? {
     if (countries.isEmpty()) return null
     val dayOfYear = System.currentTimeMillis() / (1000 * 60 * 60 * 24)
     val index = (dayOfYear % countries.size).toInt()

--- a/feature/widget/src/test/kotlin/com/vamsi/worldcountriesinformation/feature/widget/data/WidgetDataSourceTest.kt
+++ b/feature/widget/src/test/kotlin/com/vamsi/worldcountriesinformation/feature/widget/data/WidgetDataSourceTest.kt
@@ -3,7 +3,7 @@ package com.vamsi.worldcountriesinformation.feature.widget.data
 import com.vamsi.worldcountriesinformation.domain.core.ApiResponse
 import com.vamsi.worldcountriesinformation.domain.core.CachePolicy
 import com.vamsi.worldcountriesinformation.domain.countries.GetCountriesUseCase
-import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -21,16 +21,13 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class WidgetDataSourceTest {
 
-    private val testCountry = Country(
+    private val testCountry = CountrySummary(
         name = "Testland",
         capital = "Test City",
-        languages = emptyList(),
         twoLetterCode = "TL",
         threeLetterCode = "TLS",
         population = 1,
         region = "Test",
-        currencies = emptyList(),
-        callingCode = "+1",
         latitude = 0.0,
         longitude = 0.0,
     )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,7 @@ include(
     ":data:countries",
     ":feature:countries",
     ":feature:countrydetails",
+    ":feature:compare",
     ":feature:settings",
     ":feature:widget"
 )

--- a/tests-shared/src/main/java/com/vamsi/worldcountriesinformation/tests_shared/TestData.kt
+++ b/tests-shared/src/main/java/com/vamsi/worldcountriesinformation/tests_shared/TestData.kt
@@ -1,6 +1,7 @@
 package com.vamsi.worldcountriesinformation.tests_shared
 
 import com.vamsi.worldcountriesinformation.domainmodel.Country
+import com.vamsi.worldcountriesinformation.domainmodel.CountrySummary
 import com.vamsi.worldcountriesinformation.domainmodel.Currency
 import com.vamsi.worldcountriesinformation.domainmodel.Language
 
@@ -23,6 +24,13 @@ object TestData {
         return listOf(
             Country("India", "New Delhi", languages, "IN", "IND", 1295210000, "Asia", currencies, "91", 20.0, 77.0),
             Country("United States of America", "Washington, D.C.", languages, "US", "USA", 323947000, "Americas", currencies, "1", 38.0, -97.0)
+        )
+    }
+
+    fun getCountrySummaries(): List<CountrySummary> {
+        return listOf(
+            CountrySummary("India", "New Delhi", "Asia", 1295210000, "IN", "IND", 20.0, 77.0),
+            CountrySummary("United States of America", "Washington, D.C.", "Americas", 323947000, "US", "USA", 38.0, -97.0),
         )
     }
 }


### PR DESCRIPTION
## Summary
- **3.4 Country split** — Introduce `CountrySummary` (light projection) for list/search/region flows; full `Country` retained for detail screen. Reduces memory pressure on the list path.
- **5.4 Smart search ranking** — New `SearchRanker` (Jaro-Winkler + exact/prefix/substring tiers, recency + favorite boosts) wired into countries search.
- **5.1 Compare countries** — New `:feature:compare` module. Long-press a country to enter selection mode, pick 2–3, tap Compare for side-by-side view (capital, region, population, languages, currencies, calling code).
- **5.6 Deep links** — App Links (`https://worldcountries.vamsi.dev/country/{code}` with `autoVerify`) and custom scheme (`wci://country/{code}`) route directly to country details.

## Test plan
- [ ] Launch app — countries list loads and scrolls smoothly
- [ ] Search "uni", "can", "ger" — fuzzy + prefix ranking returns expected order
- [ ] Mark a country as favorite, search again — favorited match floats up
- [ ] View a country (recents updated), search again — recent match boosted
- [ ] Long-press a country card — selection mode enters; tap others to add (max 3)
- [ ] Tap Compare — side-by-side screen shows all selected countries
- [ ] Compare with 1 selected — Compare action stays disabled
- [ ] Tap a country → details load with full data (languages, currencies, etc.)
- [ ] `adb shell am start -a android.intent.action.VIEW -d "wci://country/USA"` → opens USA details
- [ ] `adb shell am start -a android.intent.action.VIEW -d "https://worldcountries.vamsi.dev/country/DEU"` → opens Germany details
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew lintDebug` clean